### PR TITLE
Added a Pokemon database file

### DIFF
--- a/data/pokemondb.json
+++ b/data/pokemondb.json
@@ -1,0 +1,22034 @@
+{
+    "Bulbasaur": {
+        "id": "001",
+        "name": "Bulbasaur",
+        "species": "Seed Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "15.2 lbs (6.9 kg)",
+        "abilities": [
+            "Overgrow",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 49,
+            "defense": 49,
+            "sp.atk": 65,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 318
+        },
+        "evolution": [
+            "Bulbasaur",
+            "Ivysaur",
+            "Venusaur"
+        ],
+        "description": "For some time after its birth, it grows by gaining nourishment from the seed on its back.",
+        "gen": 1
+    },
+    "Ivysaur": {
+        "id": "002",
+        "name": "Ivysaur",
+        "species": "Seed Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "28.7 lbs (13.0 kg)",
+        "abilities": [
+            "Overgrow",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 62,
+            "defense": 63,
+            "sp.atk": 80,
+            "sp.def": 80,
+            "speed": 60,
+            "total": 405
+        },
+        "evolution": [
+            "Bulbasaur",
+            "Ivysaur",
+            "Venusaur"
+        ],
+        "description": "When the bud on its back starts swelling, a sweet aroma wafts to indicate the flowers coming bloom.",
+        "gen": 1
+    },
+    "Venusaur": {
+        "id": "003",
+        "name": "Venusaur",
+        "species": "Seed Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "6ft.7in. (2.01m)",
+        "weight": "220.5 lbs (100.0 kg)",
+        "abilities": [
+            "Overgrow",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 82,
+            "defense": 83,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 80,
+            "total": 525
+        },
+        "evolution": [
+            "Bulbasaur",
+            "Ivysaur",
+            "Venusaur"
+        ],
+        "description": "After a rainy day, the flower on its back smells stronger. The scent attracts other Pokemon.",
+        "gen": 1
+    },
+    "Charmander": {
+        "id": "004",
+        "name": "Charmander",
+        "species": "Lizard Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "18.7 lbs (8.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Solar Power"
+        ],
+        "stats": {
+            "hp": 39,
+            "attack": 52,
+            "defense": 43,
+            "sp.atk": 60,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 309
+        },
+        "evolution": [
+            "Charmander",
+            "Charmeleon",
+            "Charizard"
+        ],
+        "description": "The fire on the tip of its tail is a measure of its life. If healthy, its tail burns intensely.",
+        "gen": 1
+    },
+    "Charmeleon": {
+        "id": "005",
+        "name": "Charmeleon",
+        "species": "Flame Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "41.9 lbs (19.0 kg)",
+        "abilities": [
+            "Blaze",
+            "Solar Power"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 64,
+            "defense": 58,
+            "sp.atk": 80,
+            "sp.def": 65,
+            "speed": 80,
+            "total": 405
+        },
+        "evolution": [
+            "Charmander",
+            "Charmeleon",
+            "Charizard"
+        ],
+        "description": "In the rocky mountains where Charmeleon live, their fiery tails shine at night like stars.",
+        "gen": 1
+    },
+    "Charizard": {
+        "id": "006",
+        "name": "Charizard",
+        "species": "Flame Pokemon",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "199.5 lbs (90.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Solar Power"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 84,
+            "defense": 78,
+            "sp.atk": 109,
+            "sp.def": 85,
+            "speed": 100,
+            "total": 534
+        },
+        "evolution": [
+            "Charmander",
+            "Charmeleon",
+            "Charizard"
+        ],
+        "description": "It is said that Charizards fire burns hotter if it has experienced harsh battles.",
+        "gen": 1
+    },
+    "Squirtle": {
+        "id": "007",
+        "name": "Squirtle",
+        "species": "Tiny Turtle Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "19.8 lbs (9.0 kg)",
+        "abilities": [
+            "Torrent",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 48,
+            "defense": 65,
+            "sp.atk": 50,
+            "sp.def": 64,
+            "speed": 43,
+            "total": 314
+        },
+        "evolution": [
+            "Squirtle",
+            "Wartortle",
+            "Blastoise"
+        ],
+        "description": "It shelters itself in its shell then strikes back with spouts of water at every opportunity.",
+        "gen": 1
+    },
+    "Wartortle": {
+        "id": "008",
+        "name": "Wartortle",
+        "species": "Turtle Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "49.6 lbs (22.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 63,
+            "defense": 80,
+            "sp.atk": 65,
+            "sp.def": 80,
+            "speed": 58,
+            "total": 405
+        },
+        "evolution": [
+            "Squirtle",
+            "Wartortle",
+            "Blastoise"
+        ],
+        "description": "It is said to live 10,000 years. Its furry tail is popular as a symbol of longevity.",
+        "gen": 1
+    },
+    "Blastoise": {
+        "id": "009",
+        "name": "Blastoise",
+        "species": "Shellfish Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "188.5 lbs (85.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 79,
+            "attack": 83,
+            "defense": 100,
+            "sp.atk": 85,
+            "sp.def": 105,
+            "speed": 78,
+            "total": 530
+        },
+        "evolution": [
+            "Squirtle",
+            "Wartortle",
+            "Blastoise"
+        ],
+        "description": "The jets of water it spouts from the rocket cannons on its shell can punch through thick steel.",
+        "gen": 1
+    },
+    "Caterpie": {
+        "id": "010",
+        "name": "Caterpie",
+        "species": "Worm Pokemon",
+        "type": [
+            "Bug"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "6.4 lbs (2.9 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 30,
+            "defense": 35,
+            "sp.atk": 20,
+            "sp.def": 20,
+            "speed": 45,
+            "total": 195
+        },
+        "evolution": [
+            "Caterpie",
+            "Metapod",
+            "Butterfree"
+        ],
+        "description": "It releases a stench from its red antenna to repel enemies. It grows by molting repeatedly.",
+        "gen": 1
+    },
+    "Metapod": {
+        "id": "011",
+        "name": "Metapod",
+        "species": "Cocoon Pokemon",
+        "type": [
+            "Bug"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "21.8 lbs (9.9 kg)",
+        "abilities": [
+            "Shed Skin"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 20,
+            "defense": 55,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 30,
+            "total": 205
+        },
+        "evolution": [
+            "Caterpie",
+            "Metapod",
+            "Butterfree"
+        ],
+        "description": "A steel-hard shell protects its tender body. It quietly endures hardships while awaiting evolution.",
+        "gen": 1
+    },
+    "Butterfree": {
+        "id": "012",
+        "name": "Butterfree",
+        "species": "Butterfly Pokemon",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "70.5 lbs (32.0 kg)",
+        "abilities": [
+            "Compound Eyes",
+            "Tinted Lens"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 45,
+            "defense": 50,
+            "sp.atk": 90,
+            "sp.def": 80,
+            "speed": 70,
+            "total": 395
+        },
+        "evolution": [
+            "Caterpie",
+            "Metapod",
+            "Butterfree"
+        ],
+        "description": "It loves the honey of flowers and can locate flower patches that have even tiny amounts of pollen.",
+        "gen": 1
+    },
+    "Weedle": {
+        "id": "013",
+        "name": "Weedle",
+        "species": "Hairy Bug Pokemon",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "7.1 lbs (3.2 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 35,
+            "defense": 30,
+            "sp.atk": 20,
+            "sp.def": 20,
+            "speed": 50,
+            "total": 195
+        },
+        "evolution": [
+            "Weedle",
+            "Kakuna",
+            "Beedrill"
+        ],
+        "description": "It eats its weight in leaves every day. It fends off attackers with the needle on its head.",
+        "gen": 1
+    },
+    "Kakuna": {
+        "id": "014",
+        "name": "Kakuna",
+        "species": "Cocoon Pokemon",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "22 lbs (10.0 kg)",
+        "abilities": [
+            "Shed Skin"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 25,
+            "defense": 50,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 35,
+            "total": 205
+        },
+        "evolution": [
+            "Weedle",
+            "Kakuna",
+            "Beedrill"
+        ],
+        "description": "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+        "gen": 1
+    },
+    "Beedrill": {
+        "id": "015",
+        "name": "Beedrill",
+        "species": "Poison Bee Pokemon",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "65 lbs (29.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Sniper"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 90,
+            "defense": 40,
+            "sp.atk": 45,
+            "sp.def": 80,
+            "speed": 75,
+            "total": 395
+        },
+        "evolution": [
+            "Weedle",
+            "Kakuna",
+            "Beedrill"
+        ],
+        "description": "Its best attack involves flying around at high speed, striking with poison needles, then flying off.",
+        "gen": 1
+    },
+    "Pidgey": {
+        "id": "016",
+        "name": "Pidgey",
+        "species": "Tiny Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "4 lbs (1.8 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Tangled Feet",
+            "Big Pecks"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 40,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 56,
+            "total": 251
+        },
+        "evolution": [
+            "Pidgey",
+            "Pidgeotto",
+            "Pidgeot"
+        ],
+        "description": "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
+        "gen": 1
+    },
+    "Pidgeotto": {
+        "id": "017",
+        "name": "Pidgeotto",
+        "species": "Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Tangled Feet",
+            "Big Pecks"
+        ],
+        "stats": {
+            "hp": 63,
+            "attack": 60,
+            "defense": 55,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 71,
+            "total": 349
+        },
+        "evolution": [
+            "Pidgey",
+            "Pidgeotto",
+            "Pidgeot"
+        ],
+        "description": "It flies over its wide territory in search of prey, downing it with its highly developed claws.",
+        "gen": 1
+    },
+    "Pidgeot": {
+        "id": "018",
+        "name": "Pidgeot",
+        "species": "Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "87.1 lbs (39.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Tangled Feet",
+            "Big Pecks"
+        ],
+        "stats": {
+            "hp": 83,
+            "attack": 80,
+            "defense": 75,
+            "sp.atk": 70,
+            "sp.def": 70,
+            "speed": 101,
+            "total": 479
+        },
+        "evolution": [
+            "Pidgey",
+            "Pidgeotto",
+            "Pidgeot"
+        ],
+        "description": "It flies over its wide territory in search of prey, downing it with its highly developed claws.",
+        "gen": 1
+    },
+    "Rattata": {
+        "id": "019",
+        "name": "Rattata",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "7.7 lbs (3.5 kg)",
+        "abilities": [
+            "Guts",
+            "Run Away",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 56,
+            "defense": 35,
+            "sp.atk": 25,
+            "sp.def": 35,
+            "speed": 72,
+            "total": 253
+        },
+        "evolution": [
+            "Rattata",
+            "Raticate"
+        ],
+        "description": "It searches for food all day. It gnaws on hard objects to wear down its fangs, which grow constantly during its lifetime.",
+        "gen": 1
+    },
+    "Raticate": {
+        "id": "020",
+        "name": "Raticate",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "40.8 lbs (18.5 kg)",
+        "abilities": [
+            "Guts",
+            "Run Away",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 81,
+            "defense": 60,
+            "sp.atk": 50,
+            "sp.def": 70,
+            "speed": 97,
+            "total": 413
+        },
+        "evolution": [
+            "Rattata",
+            "Raticate"
+        ],
+        "description": "With its long fangs, this surprisingly violent Pokemon can gnaw away even thick concrete with ease.",
+        "gen": 1
+    },
+    "Spearow": {
+        "id": "021",
+        "name": "Spearow",
+        "species": "Tiny Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "4.4 lbs (2.0 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sniper"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 60,
+            "defense": 30,
+            "sp.atk": 31,
+            "sp.def": 31,
+            "speed": 70,
+            "total": 262
+        },
+        "evolution": [
+            "Spearow",
+            "Fearow"
+        ],
+        "description": "It flaps its small wings busily to fly. Using its beak, it searches in grass for prey.",
+        "gen": 1
+    },
+    "Fearow": {
+        "id": "022",
+        "name": "Fearow",
+        "species": "Beak Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "83.8 lbs (38.0 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sniper"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 90,
+            "defense": 65,
+            "sp.atk": 61,
+            "sp.def": 61,
+            "speed": 100,
+            "total": 442
+        },
+        "evolution": [
+            "Spearow",
+            "Fearow"
+        ],
+        "description": "It has the stamina to fly all day on its broad wings. It fights by using its sharp beak.",
+        "gen": 1
+    },
+    "Ekans": {
+        "id": "023",
+        "name": "Ekans",
+        "species": "Snake Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "6ft.7in. (2.01m)",
+        "weight": "15.2 lbs (6.9 kg)",
+        "abilities": [
+            "Intimidate",
+            "Shed Skin",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 60,
+            "defense": 44,
+            "sp.atk": 40,
+            "sp.def": 54,
+            "speed": 55,
+            "total": 288
+        },
+        "evolution": [
+            "Ekans",
+            "Arbok"
+        ],
+        "description": "It sneaks through grass without making a sound and strikes unsuspecting prey from behind.",
+        "gen": 1
+    },
+    "Arbok": {
+        "id": "024",
+        "name": "Arbok",
+        "species": "Cobra Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "11ft.6in. (3.51m)",
+        "weight": "143.3 lbs (65.0 kg)",
+        "abilities": [
+            "Intimidate",
+            "Shed Skin",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 69,
+            "sp.atk": 65,
+            "sp.def": 79,
+            "speed": 80,
+            "total": 438
+        },
+        "evolution": [
+            "Ekans",
+            "Arbok"
+        ],
+        "description": "The pattern on its belly is for intimidation. It constricts foes while they are frozen in fear.",
+        "gen": 1
+    },
+    "Pikachu": {
+        "id": "025",
+        "name": "Pikachu",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "13.2 lbs (6.0 kg)",
+        "abilities": [
+            "Static",
+            "Lightning Rod"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 55,
+            "defense": 40,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 90,
+            "total": 320
+        },
+        "evolution": [
+            "Pikachu",
+            "Raichu"
+        ],
+        "description": "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state.",
+        "gen": 1
+    },
+    "Raichu": {
+        "id": "026",
+        "name": "Raichu",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Static",
+            "Lightning Rod"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 90,
+            "defense": 55,
+            "sp.atk": 90,
+            "sp.def": 80,
+            "speed": 110,
+            "total": 485
+        },
+        "evolution": [
+            "Pikachu",
+            "Raichu"
+        ],
+        "description": "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+        "gen": 1
+    },
+    "Sandshrew": {
+        "id": "027",
+        "name": "Sandshrew",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "26.5 lbs (12.0 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Sand Rush"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 75,
+            "defense": 85,
+            "sp.atk": 20,
+            "sp.def": 30,
+            "speed": 40,
+            "total": 300
+        },
+        "evolution": [
+            "Sandshrew",
+            "Sandslash"
+        ],
+        "description": "It digs deep burrows to live in. When in danger, it rolls up its body to withstand attacks.",
+        "gen": 1
+    },
+    "Sandslash": {
+        "id": "028",
+        "name": "Sandslash",
+        "species": "Mouse Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "65 lbs (29.5 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Sand Rush"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 100,
+            "defense": 110,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 65,
+            "total": 450
+        },
+        "evolution": [
+            "Sandshrew",
+            "Sandslash"
+        ],
+        "description": "The spikes on its body are made up of its hardened hide. It rolls up and attacks foes with its spikes.",
+        "gen": 1
+    },
+    "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u201a\u00ac": {
+        "id": "029",
+        "name": "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u201a\u00ac",
+        "species": "Poison Pin Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "15.4 lbs (7.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 47,
+            "defense": 52,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 41,
+            "total": 275
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u201a\u00ac",
+            "Nidorina",
+            "Nidoqueen"
+        ],
+        "description": "While it does not prefer to fight, even one drop of the poison it secretes from barbs can be fatal.",
+        "gen": 1
+    },
+    "Nidorina": {
+        "id": "030",
+        "name": "Nidorina",
+        "species": "Poison Pin Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "44.1 lbs (20.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 62,
+            "defense": 67,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 56,
+            "total": 365
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u201a\u00ac",
+            "Nidorina",
+            "Nidoqueen"
+        ],
+        "description": "When it senses danger, it raises all the barbs on its body. These barbs grow slower than Nidorinos.",
+        "gen": 1
+    },
+    "Nidoqueen": {
+        "id": "031",
+        "name": "Nidoqueen",
+        "species": "Drill Pokemon",
+        "type": [
+            "Poison",
+            "Ground"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "132.3 lbs (60.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 92,
+            "defense": 87,
+            "sp.atk": 75,
+            "sp.def": 85,
+            "speed": 76,
+            "total": 505
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u201a\u00ac",
+            "Nidorina",
+            "Nidoqueen"
+        ],
+        "description": "Its entire body is armored with hard scales. It will protect the young in its burrow with its life.",
+        "gen": 1
+    },
+    "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u20ac\u0161": {
+        "id": "032",
+        "name": "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u20ac\u0161",
+        "species": "Poison Pin Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "19.8 lbs (9.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 46,
+            "attack": 57,
+            "defense": 40,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 50,
+            "total": 273
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u20ac\u0161",
+            "Nidorino",
+            "Nidoking"
+        ],
+        "description": "It scans its surroundings by raising its ears out of the grass. Its toxic horn is for protection.",
+        "gen": 1
+    },
+    "Nidorino": {
+        "id": "033",
+        "name": "Nidorino",
+        "species": "Poison Pin Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "43 lbs (19.5 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 61,
+            "attack": 72,
+            "defense": 57,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 65,
+            "total": 365
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u20ac\u0161",
+            "Nidorino",
+            "Nidoking"
+        ],
+        "description": "It has a violent disposition and stabs foes with its horn, which oozes poison upon impact.",
+        "gen": 1
+    },
+    "Nidoking": {
+        "id": "034",
+        "name": "Nidoking",
+        "species": "Drill Pokemon",
+        "type": [
+            "Poison",
+            "Ground"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "136.7 lbs (62.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Rivalry",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 81,
+            "attack": 102,
+            "defense": 77,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 85,
+            "total": 505
+        },
+        "evolution": [
+            "Nidoran\u00c3\u00a2\u00e2\u201e\u00a2\u00e2\u20ac\u0161",
+            "Nidorino",
+            "Nidoking"
+        ],
+        "description": "One swing of its mighty tail can snap a telephone pole as if it were a matchstick.",
+        "gen": 1
+    },
+    "Clefairy": {
+        "id": "035",
+        "name": "Clefairy",
+        "species": "Fairy Pokemon",
+        "type": [
+            "Fairy"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "16.5 lbs (7.5 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Magic Guard",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 45,
+            "defense": 48,
+            "sp.atk": 60,
+            "sp.def": 65,
+            "speed": 35,
+            "total": 323
+        },
+        "evolution": [
+            "Cleffa",
+            "Clefairy",
+            "Clefable"
+        ],
+        "description": "On nights with a full moon, Clefairy gather from all over and dance. Bathing in moonlight makes them float.",
+        "gen": 1
+    },
+    "Clefable": {
+        "id": "036",
+        "name": "Clefable",
+        "species": "Fairy Pokemon",
+        "type": [
+            "Fairy"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "88.2 lbs (40.0 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Magic Guard",
+            "Unaware"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 70,
+            "defense": 73,
+            "sp.atk": 95,
+            "sp.def": 90,
+            "speed": 60,
+            "total": 483
+        },
+        "evolution": [
+            "Cleffa",
+            "Clefairy",
+            "Clefable"
+        ],
+        "description": "Their ears are sensitive enough to hear a pin drop from over a mile away, so theyre usually found in quiet places.",
+        "gen": 1
+    },
+    "Vulpix": {
+        "id": "037",
+        "name": "Vulpix",
+        "species": "Fox Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "21.8 lbs (9.9 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Drought"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 41,
+            "defense": 40,
+            "sp.atk": 50,
+            "sp.def": 65,
+            "speed": 65,
+            "total": 299
+        },
+        "evolution": [
+            "Vulpix",
+            "Ninetales"
+        ],
+        "description": "As each tail grows, its fur becomes more lustrous. When held, it feels slightly warm.",
+        "gen": 1
+    },
+    "Ninetales": {
+        "id": "038",
+        "name": "Ninetales",
+        "species": "Fox Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "43.9 lbs (19.9 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Drought"
+        ],
+        "stats": {
+            "hp": 73,
+            "attack": 76,
+            "defense": 75,
+            "sp.atk": 81,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 505
+        },
+        "evolution": [
+            "Vulpix",
+            "Ninetales"
+        ],
+        "description": "Each of its nine tails is imbued with supernatural power, and it can live for a thousand years.",
+        "gen": 1
+    },
+    "Jigglypuff": {
+        "id": "039",
+        "name": "Jigglypuff",
+        "species": "Balloon Pokemon",
+        "type": [
+            "Normal",
+            "Fairy"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "12.1 lbs (5.5 kg)",
+        "abilities": [
+            "Competitive",
+            "Cute Charm",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 115,
+            "attack": 45,
+            "defense": 20,
+            "sp.atk": 45,
+            "sp.def": 25,
+            "speed": 20,
+            "total": 270
+        },
+        "evolution": [
+            "Jigglypuff",
+            "Wigglytuff"
+        ],
+        "description": "Looking into its cute, round eyes makes it start singing a song so pleasant listeners cant help but fall asleep.",
+        "gen": 1
+    },
+    "Wigglytuff": {
+        "id": "040",
+        "name": "Wigglytuff",
+        "species": "Balloon Pokemon",
+        "type": [
+            "Normal",
+            "Fairy"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "26.5 lbs (12.0 kg)",
+        "abilities": [
+            "Competitive",
+            "Cute Charm",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 140,
+            "attack": 70,
+            "defense": 45,
+            "sp.atk": 85,
+            "sp.def": 50,
+            "speed": 45,
+            "total": 435
+        },
+        "evolution": [
+            "Jigglypuff",
+            "Wigglytuff"
+        ],
+        "description": "Its fine fur feels so pleasant, those who accidentally touch it cannot take their hands away.",
+        "gen": 1
+    },
+    "Zubat": {
+        "id": "041",
+        "name": "Zubat",
+        "species": "Bat Pokemon",
+        "type": [
+            "Poison",
+            "Flying"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "16.5 lbs (7.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 35,
+            "sp.atk": 30,
+            "sp.def": 40,
+            "speed": 55,
+            "total": 245
+        },
+        "evolution": [
+            "Zubat",
+            "Golbat",
+            "Crobat"
+        ],
+        "description": "It does not need eyes, because it emits ultrasonic waves to check its surroundings while it flies.",
+        "gen": 1
+    },
+    "Golbat": {
+        "id": "042",
+        "name": "Golbat",
+        "species": "Bat Pokemon",
+        "type": [
+            "Poison",
+            "Flying"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "121.3 lbs (55.0 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 80,
+            "defense": 70,
+            "sp.atk": 65,
+            "sp.def": 75,
+            "speed": 90,
+            "total": 455
+        },
+        "evolution": [
+            "Zubat",
+            "Golbat",
+            "Crobat"
+        ],
+        "description": "Flitting around in the dead of night, it sinks its fangs into its prey and drains a nearly fatal amount of blood.",
+        "gen": 1
+    },
+    "Oddish": {
+        "id": "043",
+        "name": "Oddish",
+        "species": "Weed Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "11.9 lbs (5.4 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 50,
+            "defense": 55,
+            "sp.atk": 75,
+            "sp.def": 65,
+            "speed": 30,
+            "total": 320
+        },
+        "evolution": [
+            "Oddish",
+            "Gloom",
+            "Vileplume"
+        ],
+        "description": "It often plants its root feet in the ground during the day and sows seeds as it walks about at night.",
+        "gen": 1
+    },
+    "Gloom": {
+        "id": "044",
+        "name": "Gloom",
+        "species": "Weed Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "19 lbs (8.6 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Stench"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 65,
+            "defense": 70,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 40,
+            "total": 395
+        },
+        "evolution": [
+            "Oddish",
+            "Gloom",
+            "Vileplume"
+        ],
+        "description": "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
+        "gen": 1
+    },
+    "Vileplume": {
+        "id": "045",
+        "name": "Vileplume",
+        "species": "Flower Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "41 lbs (18.6 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Effect Spore"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 80,
+            "defense": 85,
+            "sp.atk": 110,
+            "sp.def": 90,
+            "speed": 50,
+            "total": 490
+        },
+        "evolution": [
+            "Oddish",
+            "Gloom",
+            "Vileplume"
+        ],
+        "description": "Its petals are the largest in the world. As it walks, it scatters extremely allergenic pollen.",
+        "gen": 1
+    },
+    "Paras": {
+        "id": "046",
+        "name": "Paras",
+        "species": "Mushroom Pokemon",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "11.9 lbs (5.4 kg)",
+        "abilities": [
+            "Dry Skin",
+            "Effect Spore",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 70,
+            "defense": 55,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 25,
+            "total": 285
+        },
+        "evolution": [
+            "Paras",
+            "Parasect"
+        ],
+        "description": "Mushrooms named tochukaso grow on its back. They grow along with the host Paras.",
+        "gen": 1
+    },
+    "Parasect": {
+        "id": "047",
+        "name": "Parasect",
+        "species": "Mushroom Pokemon",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "65 lbs (29.5 kg)",
+        "abilities": [
+            "Dry Skin",
+            "Effect Spore",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 95,
+            "defense": 80,
+            "sp.atk": 60,
+            "sp.def": 80,
+            "speed": 30,
+            "total": 405
+        },
+        "evolution": [
+            "Paras",
+            "Parasect"
+        ],
+        "description": "A mushroom grown larger than the hosts body controls Parasect. It scatters poisonous spores.",
+        "gen": 1
+    },
+    "Venonat": {
+        "id": "048",
+        "name": "Venonat",
+        "species": "Insect Pokemon",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Compound Eyes",
+            "Tinted Lens",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 55,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 55,
+            "speed": 45,
+            "total": 305
+        },
+        "evolution": [
+            "Venonat",
+            "Venomoth"
+        ],
+        "description": "Its big eyes are actually clusters of tiny eyes. At night, its kind is drawn by light.",
+        "gen": 1
+    },
+    "Venomoth": {
+        "id": "049",
+        "name": "Venomoth",
+        "species": "Poison Moth Pokemon",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "27.6 lbs (12.5 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Tinted Lens",
+            "Wonder Skin"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 65,
+            "defense": 60,
+            "sp.atk": 90,
+            "sp.def": 75,
+            "speed": 90,
+            "total": 450
+        },
+        "evolution": [
+            "Venonat",
+            "Venomoth"
+        ],
+        "description": "It flutters its wings to scatter dustlike scales. The scales leach toxins if they contact skin.",
+        "gen": 1
+    },
+    "Diglett": {
+        "id": "050",
+        "name": "Diglett",
+        "species": "Mole Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "0ft.8in. (0.20m)",
+        "weight": "1.8 lbs (0.8 kg)",
+        "abilities": [
+            "Arena Trap",
+            "Sand Veil",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 10,
+            "attack": 55,
+            "defense": 25,
+            "sp.atk": 35,
+            "sp.def": 45,
+            "speed": 95,
+            "total": 265
+        },
+        "evolution": [
+            "Diglett",
+            "Dugtrio"
+        ],
+        "description": "A Pokemon that lives underground. Because of its dark habitat, it is repelled by bright sunlight.",
+        "gen": 1
+    },
+    "Dugtrio": {
+        "id": "051",
+        "name": "Dugtrio",
+        "species": "Mole Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "73.4 lbs (33.3 kg)",
+        "abilities": [
+            "Arena Trap",
+            "Sand Veil",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 80,
+            "defense": 50,
+            "sp.atk": 50,
+            "sp.def": 70,
+            "speed": 120,
+            "total": 405
+        },
+        "evolution": [
+            "Diglett",
+            "Dugtrio"
+        ],
+        "description": "Its three heads move alternately, driving it through tough soil to depths of over 60 miles.",
+        "gen": 1
+    },
+    "Meowth": {
+        "id": "052",
+        "name": "Meowth",
+        "species": "Scratch Cat Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "9.3 lbs (4.2 kg)",
+        "abilities": [
+            "Pickup",
+            "Technician",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 35,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 90,
+            "total": 290
+        },
+        "evolution": [
+            "Meowth",
+            "Persian"
+        ],
+        "description": "It is nocturnal in nature. If it spots something shiny, its eyes glitter brightly.",
+        "gen": 1
+    },
+    "Persian": {
+        "id": "053",
+        "name": "Persian",
+        "species": "Classy Cat Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "70.5 lbs (32.0 kg)",
+        "abilities": [
+            "Limber",
+            "Technician",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 70,
+            "defense": 60,
+            "sp.atk": 65,
+            "sp.def": 65,
+            "speed": 115,
+            "total": 440
+        },
+        "evolution": [
+            "Meowth",
+            "Persian"
+        ],
+        "description": "A very haughty Pokemon. Among fans, the size of the jewel in its forehead is a topic of much talk.",
+        "gen": 1
+    },
+    "Psyduck": {
+        "id": "054",
+        "name": "Psyduck",
+        "species": "Duck Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "43.2 lbs (19.6 kg)",
+        "abilities": [
+            "Cloud Nine",
+            "Damp",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 52,
+            "defense": 48,
+            "sp.atk": 65,
+            "sp.def": 50,
+            "speed": 55,
+            "total": 320
+        },
+        "evolution": [
+            "Psyduck",
+            "Golduck"
+        ],
+        "description": "When headaches stimulate its brain cells, which are usually inactive, it can use a mysterious power.",
+        "gen": 1
+    },
+    "Golduck": {
+        "id": "055",
+        "name": "Golduck",
+        "species": "Duck Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "168.9 lbs (76.6 kg)",
+        "abilities": [
+            "Cloud Nine",
+            "Damp",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 82,
+            "defense": 78,
+            "sp.atk": 95,
+            "sp.def": 80,
+            "speed": 85,
+            "total": 500
+        },
+        "evolution": [
+            "Psyduck",
+            "Golduck"
+        ],
+        "description": "When its forehead shines mysteriously, Golduck can use the full extent of its power.",
+        "gen": 1
+    },
+    "Mankey": {
+        "id": "056",
+        "name": "Mankey",
+        "species": "Pig Monkey Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "61.7 lbs (28.0 kg)",
+        "abilities": [
+            "Anger Point",
+            "Vital Spirit",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 80,
+            "defense": 35,
+            "sp.atk": 35,
+            "sp.def": 45,
+            "speed": 70,
+            "total": 305
+        },
+        "evolution": [
+            "Mankey",
+            "Primeape"
+        ],
+        "description": "It lives in treetop colonies. If one becomes enraged, the whole colony rampages for no reason.",
+        "gen": 1
+    },
+    "Primeape": {
+        "id": "057",
+        "name": "Primeape",
+        "species": "Pig Monkey Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "70.5 lbs (32.0 kg)",
+        "abilities": [
+            "Anger Point",
+            "Vital Spirit",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 105,
+            "defense": 60,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 95,
+            "total": 455
+        },
+        "evolution": [
+            "Mankey",
+            "Primeape"
+        ],
+        "description": "It grows angry if you see its eyes and gets angrier if you run. If you beat it, it gets even madder.",
+        "gen": 1
+    },
+    "Growlithe": {
+        "id": "058",
+        "name": "Growlithe",
+        "species": "Puppy Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "41.9 lbs (19.0 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Intimidate",
+            "Justified"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 70,
+            "defense": 45,
+            "sp.atk": 70,
+            "sp.def": 50,
+            "speed": 60,
+            "total": 350
+        },
+        "evolution": [
+            "Growlithe",
+            "Arcanine"
+        ],
+        "description": "Extremely loyal to its Trainer, it will bark at those who approach the Trainer unexpectedly and run them out of town.",
+        "gen": 1
+    },
+    "Arcanine": {
+        "id": "059",
+        "name": "Arcanine",
+        "species": "Legendary Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "6ft.3in. (1.91m)",
+        "weight": "341.7 lbs (155.0 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Intimidate",
+            "Justified"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 110,
+            "defense": 80,
+            "sp.atk": 100,
+            "sp.def": 80,
+            "speed": 95,
+            "total": 555
+        },
+        "evolution": [
+            "Growlithe",
+            "Arcanine"
+        ],
+        "description": "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
+        "gen": 1
+    },
+    "Poliwag": {
+        "id": "060",
+        "name": "Poliwag",
+        "species": "Tadpole Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "27.3 lbs (12.4 kg)",
+        "abilities": [
+            "Damp",
+            "Water Absorb",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 50,
+            "defense": 40,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 90,
+            "total": 300
+        },
+        "evolution": [
+            "Poliwag",
+            "Poliwhirl",
+            "Poliwrath"
+        ],
+        "description": "Its skin is so thin, its internal organs are visible. It has trouble walking on its newly grown feet.",
+        "gen": 1
+    },
+    "Poliwhirl": {
+        "id": "061",
+        "name": "Poliwhirl",
+        "species": "Tadpole Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "44.1 lbs (20.0 kg)",
+        "abilities": [
+            "Damp",
+            "Water Absorb",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 65,
+            "defense": 65,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 90,
+            "total": 385
+        },
+        "evolution": [
+            "Poliwag",
+            "Poliwhirl",
+            "Poliwrath"
+        ],
+        "description": "The spiral pattern on its belly subtly undulates. Staring at it gradually causes drowsiness.",
+        "gen": 1
+    },
+    "Poliwrath": {
+        "id": "062",
+        "name": "Poliwrath",
+        "species": "Tadpole Pokemon",
+        "type": [
+            "Water",
+            "Fighting"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "119 lbs (54.0 kg)",
+        "abilities": [
+            "Damp",
+            "Water Absorb",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 95,
+            "defense": 95,
+            "sp.atk": 70,
+            "sp.def": 90,
+            "speed": 70,
+            "total": 510
+        },
+        "evolution": [
+            "Poliwag",
+            "Poliwhirl",
+            "Poliwrath"
+        ],
+        "description": "With its extremely tough muscles, it can keep swimming in the Pacific Ocean without resting.",
+        "gen": 1
+    },
+    "Abra": {
+        "id": "063",
+        "name": "Abra",
+        "species": "Psi Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "43 lbs (19.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Synchronize",
+            "Magic Guard"
+        ],
+        "stats": {
+            "hp": 25,
+            "attack": 20,
+            "defense": 15,
+            "sp.atk": 105,
+            "sp.def": 55,
+            "speed": 90,
+            "total": 310
+        },
+        "evolution": [
+            "Abra",
+            "Kadabra",
+            "Alakazam"
+        ],
+        "description": "Using its psychic power is such a strain on its brain that it needs to sleep for 18 hours a day.",
+        "gen": 1
+    },
+    "Kadabra": {
+        "id": "064",
+        "name": "Kadabra",
+        "species": "Psi Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "124.6 lbs (56.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Synchronize",
+            "Magic Guard"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 35,
+            "defense": 30,
+            "sp.atk": 120,
+            "sp.def": 70,
+            "speed": 105,
+            "total": 400
+        },
+        "evolution": [
+            "Abra",
+            "Kadabra",
+            "Alakazam"
+        ],
+        "description": "It stares at its silver spoon to focus its mind. It emits more alpha waves while doing so.",
+        "gen": 1
+    },
+    "Alakazam": {
+        "id": "065",
+        "name": "Alakazam",
+        "species": "Psi Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "105.8 lbs (48.0 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Synchronize",
+            "Magic Guard"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 50,
+            "defense": 45,
+            "sp.atk": 135,
+            "sp.def": 95,
+            "speed": 120,
+            "total": 500
+        },
+        "evolution": [
+            "Abra",
+            "Kadabra",
+            "Alakazam"
+        ],
+        "description": "The spoons clutched in its hands are said to have been created by its psychic powers.",
+        "gen": 1
+    },
+    "Machop": {
+        "id": "066",
+        "name": "Machop",
+        "species": "Superpower Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "43 lbs (19.5 kg)",
+        "abilities": [
+            "Guts",
+            "No Guard",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 80,
+            "defense": 50,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 35,
+            "total": 305
+        },
+        "evolution": [
+            "Machop",
+            "Machoke",
+            "Machamp"
+        ],
+        "description": "Though small in stature, it is powerful enough to easily heft and throw a number of Geodude at once.",
+        "gen": 1
+    },
+    "Machoke": {
+        "id": "067",
+        "name": "Machoke",
+        "species": "Superpower Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "155.4 lbs (70.5 kg)",
+        "abilities": [
+            "Guts",
+            "No Guard",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 100,
+            "defense": 70,
+            "sp.atk": 50,
+            "sp.def": 60,
+            "speed": 45,
+            "total": 405
+        },
+        "evolution": [
+            "Machop",
+            "Machoke",
+            "Machamp"
+        ],
+        "description": "It happily carries heavy cargo to toughen up. It willingly does hard work for people.",
+        "gen": 1
+    },
+    "Machamp": {
+        "id": "068",
+        "name": "Machamp",
+        "species": "Superpower Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "286.6 lbs (130.0 kg)",
+        "abilities": [
+            "Guts",
+            "No Guard",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 130,
+            "defense": 80,
+            "sp.atk": 65,
+            "sp.def": 85,
+            "speed": 55,
+            "total": 505
+        },
+        "evolution": [
+            "Machop",
+            "Machoke",
+            "Machamp"
+        ],
+        "description": "Its four muscled arms slam foes with powerful punches and chops at blinding speed.",
+        "gen": 1
+    },
+    "Bellsprout": {
+        "id": "069",
+        "name": "Bellsprout",
+        "species": "Flower Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "2ft.4in. (0.71m)",
+        "weight": "8.8 lbs (4.0 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 75,
+            "defense": 35,
+            "sp.atk": 70,
+            "sp.def": 30,
+            "speed": 40,
+            "total": 300
+        },
+        "evolution": [
+            "Bellsprout",
+            "Weepinbell",
+            "Victreebel"
+        ],
+        "description": "It prefers hot and humid environments. It is quick at capturing prey with its vines.",
+        "gen": 1
+    },
+    "Weepinbell": {
+        "id": "070",
+        "name": "Weepinbell",
+        "species": "Flycatcher Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "14.1 lbs (6.4 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 90,
+            "defense": 50,
+            "sp.atk": 85,
+            "sp.def": 45,
+            "speed": 55,
+            "total": 390
+        },
+        "evolution": [
+            "Bellsprout",
+            "Weepinbell",
+            "Victreebel"
+        ],
+        "description": "A Pokemon that appears to be a plant. It captures unwary prey by dousing them with a toxic powder.",
+        "gen": 1
+    },
+    "Victreebel": {
+        "id": "071",
+        "name": "Victreebel",
+        "species": "Flycatcher Pokemon",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "34.2 lbs (15.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 105,
+            "defense": 65,
+            "sp.atk": 100,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 490
+        },
+        "evolution": [
+            "Bellsprout",
+            "Weepinbell",
+            "Victreebel"
+        ],
+        "description": "It pools in its mouth a fluid with a honey-like scent, which is really an acid that dissolves anything.",
+        "gen": 1
+    },
+    "Tentacool": {
+        "id": "072",
+        "name": "Tentacool",
+        "species": "Jellyfish Pokemon",
+        "type": [
+            "Water",
+            "Poison"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "100.3 lbs (45.5 kg)",
+        "abilities": [
+            "Clear Body",
+            "Liquid Ooze",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 40,
+            "defense": 35,
+            "sp.atk": 50,
+            "sp.def": 100,
+            "speed": 70,
+            "total": 335
+        },
+        "evolution": [
+            "Tentacool",
+            "Tentacruel"
+        ],
+        "description": "Because its body is almost entirely composed of water, it shrivels up if it is washed ashore.",
+        "gen": 1
+    },
+    "Tentacruel": {
+        "id": "073",
+        "name": "Tentacruel",
+        "species": "Jellyfish Pokemon",
+        "type": [
+            "Water",
+            "Poison"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "121.3 lbs (55.0 kg)",
+        "abilities": [
+            "Clear Body",
+            "Liquid Ooze",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 70,
+            "defense": 65,
+            "sp.atk": 80,
+            "sp.def": 120,
+            "speed": 100,
+            "total": 515
+        },
+        "evolution": [
+            "Tentacool",
+            "Tentacruel"
+        ],
+        "description": "It extends its 80 tentacles to form an encircling poisonous net that is difficult to escape.",
+        "gen": 1
+    },
+    "Geodude": {
+        "id": "074",
+        "name": "Geodude",
+        "species": "Rock Pokemon",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "44.1 lbs (20.0 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sturdy",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 80,
+            "defense": 100,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 20,
+            "total": 300
+        },
+        "evolution": [
+            "Geodude",
+            "Graveler",
+            "Golem"
+        ],
+        "description": "At rest, it looks just like a rock. Carelessly stepping on it will make it swing its fists angrily.",
+        "gen": 1
+    },
+    "Graveler": {
+        "id": "075",
+        "name": "Graveler",
+        "species": "Rock Pokemon",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "231.5 lbs (105.0 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sturdy",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 95,
+            "defense": 115,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 35,
+            "total": 390
+        },
+        "evolution": [
+            "Geodude",
+            "Graveler",
+            "Golem"
+        ],
+        "description": "It rolls on mountain paths to move. Once it builds momentum, no Pokemon can stop it without difficulty.",
+        "gen": 1
+    },
+    "Golem": {
+        "id": "076",
+        "name": "Golem",
+        "species": "Megaton Pokemon",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "661.4 lbs (300.0 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sturdy",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 120,
+            "defense": 130,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 495
+        },
+        "evolution": [
+            "Geodude",
+            "Graveler",
+            "Golem"
+        ],
+        "description": "Even dynamite cant harm its hard, boulder-like body. It sheds its hide just once a year.",
+        "gen": 1
+    },
+    "Ponyta": {
+        "id": "077",
+        "name": "Ponyta",
+        "species": "Fire Horse Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Run Away",
+            "Flame Body"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 85,
+            "defense": 55,
+            "sp.atk": 65,
+            "sp.def": 65,
+            "speed": 90,
+            "total": 410
+        },
+        "evolution": [
+            "Ponyta",
+            "Rapidash"
+        ],
+        "description": "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
+        "gen": 1
+    },
+    "Rapidash": {
+        "id": "078",
+        "name": "Rapidash",
+        "species": "Fire Horse Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "209.4 lbs (95.0 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Run Away",
+            "Flame Body"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 100,
+            "defense": 70,
+            "sp.atk": 80,
+            "sp.def": 80,
+            "speed": 105,
+            "total": 500
+        },
+        "evolution": [
+            "Ponyta",
+            "Rapidash"
+        ],
+        "description": "When at an all-out gallop, its blazing mane sparkles, enhancing its beautiful appearance.",
+        "gen": 1
+    },
+    "Slowpoke": {
+        "id": "079",
+        "name": "Slowpoke",
+        "species": "Dopey Pokemon",
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "79.4 lbs (36.0 kg)",
+        "abilities": [
+            "Oblivious",
+            "Own Tempo",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 65,
+            "defense": 65,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 15,
+            "total": 315
+        },
+        "evolution": [
+            "Slowpoke",
+            "Slowbro"
+        ],
+        "description": "Although slow, it is skilled at fishing with its tail. It does not feel pain if its tail is bitten.",
+        "gen": 1
+    },
+    "Slowbro": {
+        "id": "080",
+        "name": "Slowbro",
+        "species": "Hermit Crab Pokemon",
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "173.1 lbs (78.5 kg)",
+        "abilities": [
+            "Oblivious",
+            "Own Tempo",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 75,
+            "defense": 110,
+            "sp.atk": 100,
+            "sp.def": 80,
+            "speed": 30,
+            "total": 490
+        },
+        "evolution": [
+            "Slowpoke",
+            "Slowbro"
+        ],
+        "description": "Though usually dim witted, it seems to become inspired if the Shellder on its tail bites down.",
+        "gen": 1
+    },
+    "Magnemite": {
+        "id": "081",
+        "name": "Magnemite",
+        "species": "Magnet Pokemon",
+        "type": [
+            "Electric",
+            "Steel"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "13.2 lbs (6.0 kg)",
+        "abilities": [
+            "Magnet Pull",
+            "Sturdy",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 25,
+            "attack": 35,
+            "defense": 70,
+            "sp.atk": 95,
+            "sp.def": 55,
+            "speed": 45,
+            "total": 325
+        },
+        "evolution": [
+            "Magnemite",
+            "Magneton"
+        ],
+        "description": "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+        "gen": 1
+    },
+    "Magneton": {
+        "id": "082",
+        "name": "Magneton",
+        "species": "Magnet Pokemon",
+        "type": [
+            "Electric",
+            "Steel"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "132.3 lbs (60.0 kg)",
+        "abilities": [
+            "Magnet Pull",
+            "Sturdy",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 60,
+            "defense": 95,
+            "sp.atk": 120,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 465
+        },
+        "evolution": [
+            "Magnemite",
+            "Magneton"
+        ],
+        "description": "The stronger electromagnetic waves from the three linked Magnemite are enough to dry out surrounding moisture.",
+        "gen": 1
+    },
+    "Farfetch'd": {
+        "id": "083",
+        "name": "Farfetch'd",
+        "species": "Wild Duck Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "33.1 lbs (15.0 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Keen Eye",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 52,
+            "attack": 65,
+            "defense": 55,
+            "sp.atk": 58,
+            "sp.def": 62,
+            "speed": 60,
+            "total": 352
+        },
+        "evolution": [],
+        "description": "It cant live without the stalk it holds. Thats why it defends the stalk from attackers with its life.",
+        "gen": 1
+    },
+    "Doduo": {
+        "id": "084",
+        "name": "Doduo",
+        "species": "Twin Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "86.4 lbs (39.2 kg)",
+        "abilities": [
+            "Early Bird",
+            "Run Away",
+            "Tangled Feet"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 85,
+            "defense": 45,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 75,
+            "total": 310
+        },
+        "evolution": [
+            "Doduo",
+            "Dodrio"
+        ],
+        "description": "The brains in its two heads appear to communicate emotions to each other with a telepathic power.",
+        "gen": 1
+    },
+    "Dodrio": {
+        "id": "085",
+        "name": "Dodrio",
+        "species": "Triple Bird Pokemon",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "5ft.11in. (1.80m)",
+        "weight": "187.8 lbs (85.2 kg)",
+        "abilities": [
+            "Early Bird",
+            "Run Away",
+            "Tangled Feet"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 110,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 100,
+            "total": 460
+        },
+        "evolution": [
+            "Doduo",
+            "Dodrio"
+        ],
+        "description": "When Doduo evolves into this odd breed, one of its heads splits into two. It runs at nearly 40 mph.",
+        "gen": 1
+    },
+    "Seel": {
+        "id": "086",
+        "name": "Seel",
+        "species": "Sea Lion Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "198.4 lbs (90.0 kg)",
+        "abilities": [
+            "Hydration",
+            "Thick Fat",
+            "Ice Body"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 45,
+            "defense": 55,
+            "sp.atk": 45,
+            "sp.def": 70,
+            "speed": 45,
+            "total": 325
+        },
+        "evolution": [
+            "Seel",
+            "Dewgong"
+        ],
+        "description": "The colder it gets, the better it feels. It joyfully swims around oceans so cold that they are filled with floating ice.",
+        "gen": 1
+    },
+    "Dewgong": {
+        "id": "087",
+        "name": "Dewgong",
+        "species": "Sea Lion Pokemon",
+        "type": [
+            "Water",
+            "Ice"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "264.6 lbs (120.0 kg)",
+        "abilities": [
+            "Hydration",
+            "Thick Fat",
+            "Ice Body"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 70,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 95,
+            "speed": 70,
+            "total": 475
+        },
+        "evolution": [
+            "Seel",
+            "Dewgong"
+        ],
+        "description": "Its streamlined body has low resistance, and it swims around cold oceans at a speed of eight knots.",
+        "gen": 1
+    },
+    "Grimer": {
+        "id": "088",
+        "name": "Grimer",
+        "species": "Sludge Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Stench",
+            "Sticky Hold",
+            "Poison Touch"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 80,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 25,
+            "total": 325
+        },
+        "evolution": [
+            "Grimer",
+            "Muk"
+        ],
+        "description": "Born from sludge, these Pokemon now gather in polluted places and increase the bacteria in their bodies.",
+        "gen": 1
+    },
+    "Muk": {
+        "id": "089",
+        "name": "Muk",
+        "species": "Sludge Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Stench",
+            "Sticky Hold",
+            "Poison Touch"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 105,
+            "defense": 75,
+            "sp.atk": 65,
+            "sp.def": 100,
+            "speed": 50,
+            "total": 500
+        },
+        "evolution": [
+            "Grimer",
+            "Muk"
+        ],
+        "description": "Its so stinky! Muks body contains toxic elements, and any plant will wilt when it passes by.",
+        "gen": 1
+    },
+    "Shellder": {
+        "id": "090",
+        "name": "Shellder",
+        "species": "Bivalve Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "8.8 lbs (4.0 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Skill Link",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 65,
+            "defense": 100,
+            "sp.atk": 45,
+            "sp.def": 25,
+            "speed": 40,
+            "total": 305
+        },
+        "evolution": [
+            "Shellder",
+            "Cloyster"
+        ],
+        "description": "It swims backward by opening and closing its two shells. Its large tongue is always kept hanging out.",
+        "gen": 1
+    },
+    "Cloyster": {
+        "id": "091",
+        "name": "Cloyster",
+        "species": "Bivalve Pokemon",
+        "type": [
+            "Water",
+            "Ice"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "292.1 lbs (132.5 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Skill Link",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 95,
+            "defense": 180,
+            "sp.atk": 85,
+            "sp.def": 45,
+            "speed": 70,
+            "total": 525
+        },
+        "evolution": [
+            "Shellder",
+            "Cloyster"
+        ],
+        "description": "It fights by keeping its shell tightly shut for protection and by shooting spikes to repel foes.",
+        "gen": 1
+    },
+    "Gastly": {
+        "id": "092",
+        "name": "Gastly",
+        "species": "Gas Pokemon",
+        "type": [
+            "Ghost",
+            "Poison"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "0.2 lbs (0.1 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 35,
+            "defense": 30,
+            "sp.atk": 100,
+            "sp.def": 35,
+            "speed": 80,
+            "total": 310
+        },
+        "evolution": [
+            "Gastly",
+            "Haunter",
+            "Gengar"
+        ],
+        "description": "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison.",
+        "gen": 1
+    },
+    "Haunter": {
+        "id": "093",
+        "name": "Haunter",
+        "species": "Gas Pokemon",
+        "type": [
+            "Ghost",
+            "Poison"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "0.2 lbs (0.1 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 50,
+            "defense": 45,
+            "sp.atk": 115,
+            "sp.def": 55,
+            "speed": 95,
+            "total": 405
+        },
+        "evolution": [
+            "Gastly",
+            "Haunter",
+            "Gengar"
+        ],
+        "description": "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering.",
+        "gen": 1
+    },
+    "Gengar": {
+        "id": "094",
+        "name": "Gengar",
+        "species": "Shadow Pokemon",
+        "type": [
+            "Ghost",
+            "Poison"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "89.3 lbs (40.5 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 65,
+            "defense": 60,
+            "sp.atk": 130,
+            "sp.def": 75,
+            "speed": 110,
+            "total": 500
+        },
+        "evolution": [
+            "Gastly",
+            "Haunter",
+            "Gengar"
+        ],
+        "description": "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people.",
+        "gen": 1
+    },
+    "Onix": {
+        "id": "095",
+        "name": "Onix",
+        "species": "Rock Snake Pokemon",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "28ft.10in. (8.79m)",
+        "weight": "463 lbs (210.0 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sturdy",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 45,
+            "defense": 160,
+            "sp.atk": 30,
+            "sp.def": 45,
+            "speed": 70,
+            "total": 385
+        },
+        "evolution": [
+            "Onix"
+        ],
+        "description": "Opening its large mouth, it ingests massive amounts of soil and creates long tunnels.",
+        "gen": 1
+    },
+    "Drowzee": {
+        "id": "096",
+        "name": "Drowzee",
+        "species": "Hypnosis Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "71.4 lbs (32.4 kg)",
+        "abilities": [
+            "Forewarn",
+            "Insomnia",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 48,
+            "defense": 45,
+            "sp.atk": 43,
+            "sp.def": 90,
+            "speed": 42,
+            "total": 328
+        },
+        "evolution": [
+            "Drowzee",
+            "Hypno"
+        ],
+        "description": "It can tell what people are dreaming by sniffing with its big nose. It loves fun dreams.",
+        "gen": 1
+    },
+    "Hypno": {
+        "id": "097",
+        "name": "Hypno",
+        "species": "Hypnosis Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "166.7 lbs (75.6 kg)",
+        "abilities": [
+            "Forewarn",
+            "Insomnia",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 73,
+            "defense": 70,
+            "sp.atk": 73,
+            "sp.def": 115,
+            "speed": 67,
+            "total": 483
+        },
+        "evolution": [
+            "Drowzee",
+            "Hypno"
+        ],
+        "description": "Seeing its swinging pendulum can induce sleep in three seconds, even in someone who just woke up.",
+        "gen": 1
+    },
+    "Krabby": {
+        "id": "098",
+        "name": "Krabby",
+        "species": "River Crab Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "14.3 lbs (6.5 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Shell Armor",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 105,
+            "defense": 90,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 50,
+            "total": 325
+        },
+        "evolution": [
+            "Krabby",
+            "Kingler"
+        ],
+        "description": "It lives in burrows dug on sandy beaches. Its pincers fully grow back if they are broken in battle.",
+        "gen": 1
+    },
+    "Kingler": {
+        "id": "099",
+        "name": "Kingler",
+        "species": "Pincer Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "132.3 lbs (60.0 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Shell Armor",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 130,
+            "defense": 115,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 75,
+            "total": 475
+        },
+        "evolution": [
+            "Krabby",
+            "Kingler"
+        ],
+        "description": "The larger pincer has 10,000- horsepower strength. However, it is so heavy, it is difficult to aim.",
+        "gen": 1
+    },
+    "Voltorb": {
+        "id": "100",
+        "name": "Voltorb",
+        "species": "Ball Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "22.9 lbs (10.4 kg)",
+        "abilities": [
+            "Soundproof",
+            "Static",
+            "Aftermath"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 50,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 100,
+            "total": 330
+        },
+        "evolution": [
+            "Voltorb",
+            "Electrode"
+        ],
+        "description": "It looks just like a Pok Ball. It is dangerous because it may electrocute or explode on contact.",
+        "gen": 1
+    },
+    "Electrode": {
+        "id": "101",
+        "name": "Electrode",
+        "species": "Ball Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "146.8 lbs (66.6 kg)",
+        "abilities": [
+            "Soundproof",
+            "Static",
+            "Aftermath"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 70,
+            "sp.atk": 80,
+            "sp.def": 80,
+            "speed": 140,
+            "total": 480
+        },
+        "evolution": [
+            "Voltorb",
+            "Electrode"
+        ],
+        "description": "It is known to drift on winds if it is bloated to bursting with stored electricity.",
+        "gen": 1
+    },
+    "Exeggcute": {
+        "id": "102",
+        "name": "Exeggcute",
+        "species": "Egg Pokemon",
+        "type": [
+            "Grass",
+            "Psychic"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "5.5 lbs (2.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Harvest"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 40,
+            "defense": 80,
+            "sp.atk": 60,
+            "sp.def": 45,
+            "speed": 40,
+            "total": 325
+        },
+        "evolution": [
+            "Exeggcute",
+            "Exeggutor"
+        ],
+        "description": "Its six eggs converse using telepathy. They can quickly gather if they become separated.",
+        "gen": 1
+    },
+    "Exeggutor": {
+        "id": "103",
+        "name": "Exeggutor",
+        "species": "Coconut Pokemon",
+        "type": [
+            "Grass",
+            "Psychic"
+        ],
+        "height": "6ft.7in. (2.01m)",
+        "weight": "264.6 lbs (120.0 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Harvest"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 95,
+            "defense": 85,
+            "sp.atk": 125,
+            "sp.def": 65,
+            "speed": 55,
+            "total": 520
+        },
+        "evolution": [
+            "Exeggcute",
+            "Exeggutor"
+        ],
+        "description": "It is called The Walking Jungle. If a head grows too big, it falls off and becomes an Exeggcute.",
+        "gen": 1
+    },
+    "Cubone": {
+        "id": "104",
+        "name": "Cubone",
+        "species": "Lonely Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "14.3 lbs (6.5 kg)",
+        "abilities": [
+            "Lightning Rod",
+            "Rock Head",
+            "Battle Armor"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 95,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 35,
+            "total": 320
+        },
+        "evolution": [
+            "Cubone",
+            "Marowak"
+        ],
+        "description": "When it thinks of its dead mother, it cries. Its crying makes the skull it wears rattle hollowly.",
+        "gen": 1
+    },
+    "Marowak": {
+        "id": "105",
+        "name": "Marowak",
+        "species": "Bone Keeper Pokemon",
+        "type": [
+            "Ground"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "99.2 lbs (45.0 kg)",
+        "abilities": [
+            "Lightning Rod",
+            "Rock Head",
+            "Battle Armor"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 80,
+            "defense": 110,
+            "sp.atk": 50,
+            "sp.def": 80,
+            "speed": 45,
+            "total": 425
+        },
+        "evolution": [
+            "Cubone",
+            "Marowak"
+        ],
+        "description": "From its birth, this savage Pokemon constantly holds bones. It is skilled in using them as weapons.",
+        "gen": 1
+    },
+    "Hitmonlee": {
+        "id": "106",
+        "name": "Hitmonlee",
+        "species": "Kicking Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "109.8 lbs (49.8 kg)",
+        "abilities": [
+            "Limber",
+            "Reckless",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 120,
+            "defense": 53,
+            "sp.atk": 35,
+            "sp.def": 110,
+            "speed": 87,
+            "total": 455
+        },
+        "evolution": [
+            "Hitmonlee",
+            "Hitmonchan"
+        ],
+        "description": "Its legs can stretch double. First-time foes are startled by its extensible reach.",
+        "gen": 1
+    },
+    "Hitmonchan": {
+        "id": "107",
+        "name": "Hitmonchan",
+        "species": "Punching Pokemon",
+        "type": [
+            "Fighting"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "110.7 lbs (50.2 kg)",
+        "abilities": [
+            "Iron Fist",
+            "Keen Eye",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 105,
+            "defense": 79,
+            "sp.atk": 35,
+            "sp.def": 110,
+            "speed": 76,
+            "total": 455
+        },
+        "evolution": [
+            "Hitmonlee",
+            "Hitmonchan"
+        ],
+        "description": "The arm-twisting punches it throws pulverize even concrete. It rests after three minutes of fighting.",
+        "gen": 1
+    },
+    "Lickitung": {
+        "id": "108",
+        "name": "Lickitung",
+        "species": "Licking Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "144.4 lbs (65.5 kg)",
+        "abilities": [
+            "Oblivious",
+            "Own Tempo",
+            "Cloud Nine"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 55,
+            "defense": 75,
+            "sp.atk": 60,
+            "sp.def": 75,
+            "speed": 30,
+            "total": 385
+        },
+        "evolution": [
+            "Lickitung"
+        ],
+        "description": "Being licked by its long, saliva-covered tongue leaves a tingling sensation. Extending its tongue retracts its tail.",
+        "gen": 1
+    },
+    "Koffing": {
+        "id": "109",
+        "name": "Koffing",
+        "species": "Poison Gas Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "2.2 lbs (1.0 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 65,
+            "defense": 95,
+            "sp.atk": 60,
+            "sp.def": 45,
+            "speed": 35,
+            "total": 340
+        },
+        "evolution": [
+            "Koffing",
+            "Weezing"
+        ],
+        "description": "Toxic gas is held within its thin, balloon-shaped body, so it can cause massive explosions.",
+        "gen": 1
+    },
+    "Weezing": {
+        "id": "110",
+        "name": "Weezing",
+        "species": "Poison Gas Pokemon",
+        "type": [
+            "Poison"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "20.9 lbs (9.5 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 90,
+            "defense": 120,
+            "sp.atk": 85,
+            "sp.def": 70,
+            "speed": 60,
+            "total": 490
+        },
+        "evolution": [
+            "Koffing",
+            "Weezing"
+        ],
+        "description": "Inhaling toxic fumes from trash and mixing them inside its body lets it spread an even fouler stench.",
+        "gen": 1
+    },
+    "Rhyhorn": {
+        "id": "111",
+        "name": "Rhyhorn",
+        "species": "Spikes Pokemon",
+        "type": [
+            "Ground",
+            "Rock"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "253.5 lbs (115.0 kg)",
+        "abilities": [
+            "Lightning Rod",
+            "Rock Head",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 85,
+            "defense": 95,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 25,
+            "total": 345
+        },
+        "evolution": [
+            "Rhyhorn",
+            "Rhydon"
+        ],
+        "description": "Its powerful tackles can destroy anything. However, it is too slow witted to help people work.",
+        "gen": 1
+    },
+    "Rhydon": {
+        "id": "112",
+        "name": "Rhydon",
+        "species": "Drill Pokemon",
+        "type": [
+            "Ground",
+            "Rock"
+        ],
+        "height": "6ft.3in. (1.91m)",
+        "weight": "264.6 lbs (120.0 kg)",
+        "abilities": [
+            "Lightning Rod",
+            "Rock Head",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 130,
+            "defense": 120,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 40,
+            "total": 485
+        },
+        "evolution": [
+            "Rhyhorn",
+            "Rhydon"
+        ],
+        "description": "Standing on its hind legs freed its forelegs and made it smarter. It is very forgetful, however.",
+        "gen": 1
+    },
+    "Chansey": {
+        "id": "113",
+        "name": "Chansey",
+        "species": "Egg Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "76.3 lbs (34.6 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Serene Grace",
+            "Healer"
+        ],
+        "stats": {
+            "hp": 250,
+            "attack": 5,
+            "defense": 5,
+            "sp.atk": 35,
+            "sp.def": 105,
+            "speed": 50,
+            "total": 450
+        },
+        "evolution": [
+            "Chansey"
+        ],
+        "description": "A kindly Pokemon that lays highly nutritious eggs and shares them with injured Pokmon or people.",
+        "gen": 1
+    },
+    "Tangela": {
+        "id": "114",
+        "name": "Tangela",
+        "species": "Vine Pokemon",
+        "type": [
+            "Grass"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "77.2 lbs (35.0 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Leaf Guard",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 55,
+            "defense": 115,
+            "sp.atk": 100,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 435
+        },
+        "evolution": [
+            "Tangela"
+        ],
+        "description": "Many writhing vines cover it, so its true identity remains unknown. The blue vines grow its whole life long.",
+        "gen": 1
+    },
+    "Kangaskhan": {
+        "id": "115",
+        "name": "Kangaskhan",
+        "species": "Parent Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "7ft.3in. (2.21m)",
+        "weight": "176.4 lbs (80.0 kg)",
+        "abilities": [
+            "Early Bird",
+            "Scrappy",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 95,
+            "defense": 80,
+            "sp.atk": 40,
+            "sp.def": 80,
+            "speed": 90,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "It raises its offspring in its belly pouch. It lets the baby out to play only when it feels safe.",
+        "gen": 1
+    },
+    "Horsea": {
+        "id": "116",
+        "name": "Horsea",
+        "species": "Dragon Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "17.6 lbs (8.0 kg)",
+        "abilities": [
+            "Sniper",
+            "Swift Swim",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 40,
+            "defense": 70,
+            "sp.atk": 70,
+            "sp.def": 25,
+            "speed": 60,
+            "total": 295
+        },
+        "evolution": [
+            "Horsea",
+            "Seadra"
+        ],
+        "description": "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
+        "gen": 1
+    },
+    "Seadra": {
+        "id": "117",
+        "name": "Seadra",
+        "species": "Dragon Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "3ft.11in. (1.19m)",
+        "weight": "55.1 lbs (25.0 kg)",
+        "abilities": [
+            "Poison Point",
+            "Sniper",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 65,
+            "defense": 95,
+            "sp.atk": 95,
+            "sp.def": 45,
+            "speed": 85,
+            "total": 440
+        },
+        "evolution": [
+            "Horsea",
+            "Seadra"
+        ],
+        "description": "Its spines provide protection. Its fins and bones are prized as traditional-medicine ingredients.",
+        "gen": 1
+    },
+    "Goldeen": {
+        "id": "118",
+        "name": "Goldeen",
+        "species": "Goldfish Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "2ft.0in. (0.61m)",
+        "weight": "33.1 lbs (15.0 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Veil",
+            "Lightning Rod"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 67,
+            "defense": 60,
+            "sp.atk": 35,
+            "sp.def": 50,
+            "speed": 63,
+            "total": 320
+        },
+        "evolution": [
+            "Goldeen",
+            "Seaking"
+        ],
+        "description": "Though it appears very elegant when swimming with fins unfurled, it can jab powerfully with its horn.",
+        "gen": 1
+    },
+    "Seaking": {
+        "id": "119",
+        "name": "Seaking",
+        "species": "Goldfish Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "86 lbs (39.0 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Veil",
+            "Lightning Rod"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 92,
+            "defense": 65,
+            "sp.atk": 65,
+            "sp.def": 80,
+            "speed": 68,
+            "total": 450
+        },
+        "evolution": [
+            "Goldeen",
+            "Seaking"
+        ],
+        "description": "In autumn, its body becomes more fatty in preparing to propose to a mate. It takes on beautiful colors.",
+        "gen": 1
+    },
+    "Staryu": {
+        "id": "120",
+        "name": "Staryu",
+        "species": "Star Shape Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "76.1 lbs (34.5 kg)",
+        "abilities": [
+            "Illuminate",
+            "Natural Cure",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 45,
+            "defense": 55,
+            "sp.atk": 70,
+            "sp.def": 55,
+            "speed": 85,
+            "total": 340
+        },
+        "evolution": [
+            "Staryu",
+            "Starmie"
+        ],
+        "description": "As long as its red core remains, it can regenerate its body instantly, even if its torn apart.",
+        "gen": 1
+    },
+    "Starmie": {
+        "id": "121",
+        "name": "Starmie",
+        "species": "Mysterious Pokemon",
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "176.4 lbs (80.0 kg)",
+        "abilities": [
+            "Illuminate",
+            "Natural Cure",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 75,
+            "defense": 85,
+            "sp.atk": 100,
+            "sp.def": 85,
+            "speed": 115,
+            "total": 520
+        },
+        "evolution": [
+            "Staryu",
+            "Starmie"
+        ],
+        "description": "Its core shines in many colors and sends radio signals into space to communicate with something.",
+        "gen": 1
+    },
+    "Mr. Mime": {
+        "id": "122",
+        "name": "Mr. Mime",
+        "species": "Barrier Pokemon",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "120.2 lbs (54.5 kg)",
+        "abilities": [
+            "Filter",
+            "Soundproof",
+            "Technician"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 65,
+            "sp.atk": 100,
+            "sp.def": 120,
+            "speed": 90,
+            "total": 460
+        },
+        "evolution": [
+            "Mr. Mime"
+        ],
+        "description": "It shapes an invisible wall in midair by minutely vibrating its fingertips to stop molecules in the air.",
+        "gen": 1
+    },
+    "Scyther": {
+        "id": "123",
+        "name": "Scyther",
+        "species": "Mantis Pokemon",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "123.5 lbs (56.0 kg)",
+        "abilities": [
+            "Swarm",
+            "Technician",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 110,
+            "defense": 80,
+            "sp.atk": 55,
+            "sp.def": 80,
+            "speed": 105,
+            "total": 500
+        },
+        "evolution": [
+            "Scyther"
+        ],
+        "description": "The sharp scythes on its forearms become increasingly sharp by cutting through hard objects.",
+        "gen": 1
+    },
+    "Jynx": {
+        "id": "124",
+        "name": "Jynx",
+        "species": "Human Shape Pokemon",
+        "type": [
+            "Ice",
+            "Psychic"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "89.5 lbs (40.6 kg)",
+        "abilities": [
+            "Forewarn",
+            "Oblivious",
+            "Dry Skin"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 50,
+            "defense": 35,
+            "sp.atk": 115,
+            "sp.def": 95,
+            "speed": 95,
+            "total": 455
+        },
+        "evolution": [
+            "Jynx"
+        ],
+        "description": "Its cries sound like human speech. However, it is impossible to tell what it is trying to say.",
+        "gen": 1
+    },
+    "Electabuzz": {
+        "id": "125",
+        "name": "Electabuzz",
+        "species": "Electric Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "3ft.7in. (1.09m)",
+        "weight": "66.1 lbs (30.0 kg)",
+        "abilities": [
+            "Static",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 83,
+            "defense": 57,
+            "sp.atk": 95,
+            "sp.def": 85,
+            "speed": 105,
+            "total": 490
+        },
+        "evolution": [
+            "Electabuzz"
+        ],
+        "description": "Research is progressing on storing lightning in Electabuzz so this energy can be used at any time.",
+        "gen": 1
+    },
+    "Magmar": {
+        "id": "126",
+        "name": "Magmar",
+        "species": "Spitfire Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "98.1 lbs (44.5 kg)",
+        "abilities": [
+            "Flame Body",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 95,
+            "defense": 57,
+            "sp.atk": 100,
+            "sp.def": 85,
+            "speed": 93,
+            "total": 495
+        },
+        "evolution": [
+            "Magmar"
+        ],
+        "description": "The scorching fire exhaled by Magmar forms heat waves around its body, making it hard to see the Pokemon clearly.",
+        "gen": 1
+    },
+    "Pinsir": {
+        "id": "127",
+        "name": "Pinsir",
+        "species": "Stag Beetle Pokemon",
+        "type": [
+            "Bug"
+        ],
+        "height": "4ft.11in. (1.50m)",
+        "weight": "121.3 lbs (55.0 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Mold Breaker",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 125,
+            "defense": 100,
+            "sp.atk": 55,
+            "sp.def": 70,
+            "speed": 85,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "It grips prey with its powerful pincers and will not let go until the prey is torn in half.",
+        "gen": 1
+    },
+    "Tauros": {
+        "id": "128",
+        "name": "Tauros",
+        "species": "Wild Bull Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "4ft.7in. (1.40m)",
+        "weight": "194.9 lbs (88.4 kg)",
+        "abilities": [
+            "Anger Point",
+            "Intimidate",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 100,
+            "defense": 95,
+            "sp.atk": 40,
+            "sp.def": 70,
+            "speed": 110,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Once it takes aim at its foe, it makes a headlong charge. It is famous for its violent nature.",
+        "gen": 1
+    },
+    "Magikarp": {
+        "id": "129",
+        "name": "Magikarp",
+        "species": "Fish Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "22 lbs (10.0 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 10,
+            "defense": 55,
+            "sp.atk": 15,
+            "sp.def": 20,
+            "speed": 80,
+            "total": 200
+        },
+        "evolution": [
+            "Magikarp",
+            "Gyarados"
+        ],
+        "description": "A Magikarp living for many years can leap a mountain using Splash. The move remains useless, though.",
+        "gen": 1
+    },
+    "Gyarados": {
+        "id": "130",
+        "name": "Gyarados",
+        "species": "Atrocious Pokemon",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "21ft.4in. (6.50m)",
+        "weight": "518.1 lbs (235.0 kg)",
+        "abilities": [
+            "Intimidate",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 125,
+            "defense": 79,
+            "sp.atk": 60,
+            "sp.def": 100,
+            "speed": 81,
+            "total": 540
+        },
+        "evolution": [
+            "Magikarp",
+            "Gyarados"
+        ],
+        "description": "Once it begins to rampage, a Gyarados will burn everything down, even in a harsh storm.",
+        "gen": 1
+    },
+    "Lapras": {
+        "id": "131",
+        "name": "Lapras",
+        "species": "Transport Pokemon",
+        "type": [
+            "Water",
+            "Ice"
+        ],
+        "height": "8ft.2in. (2.49m)",
+        "weight": "485 lbs (220.0 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Water Absorb",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 130,
+            "attack": 85,
+            "defense": 80,
+            "sp.atk": 85,
+            "sp.def": 95,
+            "speed": 60,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Able to understand human speech and very intelligent, it loves to swim in the sea with people on its back.",
+        "gen": 1
+    },
+    "Ditto": {
+        "id": "132",
+        "name": "Ditto",
+        "species": "Transform Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "8.8 lbs (4.0 kg)",
+        "abilities": [
+            "Limber",
+            "Imposter"
+        ],
+        "stats": {
+            "hp": 48,
+            "attack": 48,
+            "defense": 48,
+            "sp.atk": 48,
+            "sp.def": 48,
+            "speed": 48,
+            "total": 288
+        },
+        "evolution": [],
+        "description": "It can reconstitute its entire cellular structure to change into what it sees, but it returns to normal when it relaxes.",
+        "gen": 1
+    },
+    "Eevee": {
+        "id": "133",
+        "name": "Eevee",
+        "species": "Evolution Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "1ft.0in. (0.30m)",
+        "weight": "14.3 lbs (6.5 kg)",
+        "abilities": [
+            "Adaptability",
+            "Run Away",
+            "Anticipation"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 55,
+            "defense": 50,
+            "sp.atk": 45,
+            "sp.def": 65,
+            "speed": 55,
+            "total": 325
+        },
+        "evolution": [
+            "Vaporeon",
+            "Jolteon",
+            "Flareon",
+            "Eevee"
+        ],
+        "description": "Thanks to its unstable genetic makeup, this special Pokemon conceals many different possible evolutions.",
+        "gen": 1
+    },
+    "Vaporeon": {
+        "id": "134",
+        "name": "Vaporeon",
+        "species": "Bubble Jet Pokemon",
+        "type": [
+            "Water"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "63.9 lbs (29.0 kg)",
+        "abilities": [
+            "Water Absorb",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 130,
+            "attack": 65,
+            "defense": 60,
+            "sp.atk": 110,
+            "sp.def": 95,
+            "speed": 65,
+            "total": 525
+        },
+        "evolution": [
+            "Vaporeon",
+            "Jolteon",
+            "Flareon",
+            "Eevee"
+        ],
+        "description": "Its cell composition is similar to water molecules. As a result, it cant be seen when it melts away into water.",
+        "gen": 1
+    },
+    "Jolteon": {
+        "id": "135",
+        "name": "Jolteon",
+        "species": "Lightning Pokemon",
+        "type": [
+            "Electric"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "54 lbs (24.5 kg)",
+        "abilities": [
+            "Volt Absorb",
+            "Quick Feet"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 65,
+            "defense": 60,
+            "sp.atk": 110,
+            "sp.def": 95,
+            "speed": 130,
+            "total": 525
+        },
+        "evolution": [
+            "Vaporeon",
+            "Jolteon",
+            "Flareon",
+            "Eevee"
+        ],
+        "description": "By storing electricity in its body, it can shoot its bristlelike fur like a barrage of missiles.",
+        "gen": 1
+    },
+    "Flareon": {
+        "id": "136",
+        "name": "Flareon",
+        "species": "Flame Pokemon",
+        "type": [
+            "Fire"
+        ],
+        "height": "2ft.11in. (0.89m)",
+        "weight": "55.1 lbs (25.0 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Guts"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 130,
+            "defense": 60,
+            "sp.atk": 95,
+            "sp.def": 110,
+            "speed": 65,
+            "total": 525
+        },
+        "evolution": [
+            "Vaporeon",
+            "Jolteon",
+            "Flareon",
+            "Eevee"
+        ],
+        "description": "Inhaled air is carried to its flame sac, heated, and exhaled as fire that reaches over 3,000 degrees F.",
+        "gen": 1
+    },
+    "Porygon": {
+        "id": "137",
+        "name": "Porygon",
+        "species": "Virtual Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "2ft.7in. (0.79m)",
+        "weight": "80.5 lbs (36.5 kg)",
+        "abilities": [
+            "Download",
+            "Trace",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 60,
+            "defense": 70,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 40,
+            "total": 395
+        },
+        "evolution": [
+            "Porygon"
+        ],
+        "description": "A man-made Pokemon created using advanced scientific means. It can move freely in cyberspace.",
+        "gen": 1
+    },
+    "Omanyte": {
+        "id": "138",
+        "name": "Omanyte",
+        "species": "Spiral Pokemon",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "16.5 lbs (7.5 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Swift Swim",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 40,
+            "defense": 100,
+            "sp.atk": 90,
+            "sp.def": 55,
+            "speed": 35,
+            "total": 355
+        },
+        "evolution": [
+            "Omanyte",
+            "Omastar"
+        ],
+        "description": "A Pokemon that was resurrected from a fossil using modern science. It swam in ancient seas.",
+        "gen": 1
+    },
+    "Omastar": {
+        "id": "139",
+        "name": "Omastar",
+        "species": "Spiral Pokemon",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "3ft.3in. (0.99m)",
+        "weight": "77.2 lbs (35.0 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Swift Swim",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 60,
+            "defense": 125,
+            "sp.atk": 115,
+            "sp.def": 70,
+            "speed": 55,
+            "total": 495
+        },
+        "evolution": [
+            "Omanyte",
+            "Omastar"
+        ],
+        "description": "It is thought that this Pokemon became extinct because its spiral shell grew too large.",
+        "gen": 1
+    },
+    "Kabuto": {
+        "id": "140",
+        "name": "Kabuto",
+        "species": "Shellfish Pokemon",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "1ft.8in. (0.51m)",
+        "weight": "25.4 lbs (11.5 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Swift Swim",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 80,
+            "defense": 90,
+            "sp.atk": 55,
+            "sp.def": 45,
+            "speed": 55,
+            "total": 355
+        },
+        "evolution": [
+            "Kabuto",
+            "Kabutops"
+        ],
+        "description": "It is thought to have inhabited beaches 300 million years ago. It is protected by a stiff shell.",
+        "gen": 1
+    },
+    "Kabutops": {
+        "id": "141",
+        "name": "Kabutops",
+        "species": "Shellfish Pokemon",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "4ft.3in. (1.30m)",
+        "weight": "89.3 lbs (40.5 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Swift Swim",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 115,
+            "defense": 105,
+            "sp.atk": 65,
+            "sp.def": 70,
+            "speed": 80,
+            "total": 495
+        },
+        "evolution": [
+            "Kabuto",
+            "Kabutops"
+        ],
+        "description": "It is thought that this Pokemon came onto land because its prey adapted to life on land.",
+        "gen": 1
+    },
+    "Aerodactyl": {
+        "id": "142",
+        "name": "Aerodactyl",
+        "species": "Fossil Pokemon",
+        "type": [
+            "Rock",
+            "Flying"
+        ],
+        "height": "5ft.11in. (1.80m)",
+        "weight": "130.1 lbs (59.0 kg)",
+        "abilities": [
+            "Pressure",
+            "Rock Head",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 105,
+            "defense": 65,
+            "sp.atk": 60,
+            "sp.def": 75,
+            "speed": 130,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "A Pokemon that roamed the skies in the dinosaur era. Its teeth are like saw blades.",
+        "gen": 1
+    },
+    "Snorlax": {
+        "id": "143",
+        "name": "Snorlax",
+        "species": "Sleeping Pokemon",
+        "type": [
+            "Normal"
+        ],
+        "height": "6ft.11in. (2.11m)",
+        "weight": "1014.1 lbs (460.0 kg)",
+        "abilities": [
+            "Immunity",
+            "Thick Fat",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 160,
+            "attack": 110,
+            "defense": 65,
+            "sp.atk": 65,
+            "sp.def": 110,
+            "speed": 30,
+            "total": 540
+        },
+        "evolution": [
+            "Snorlax"
+        ],
+        "description": "When its belly is full, it becomes too lethargic to even lift a finger, so it is safe to bounce on its belly.",
+        "gen": 1
+    },
+    "Articuno": {
+        "id": "144",
+        "name": "Articuno",
+        "species": "Freeze Pokemon",
+        "type": [
+            "Ice",
+            "Flying"
+        ],
+        "height": "5ft.7in. (1.70m)",
+        "weight": "122.1 lbs (55.4 kg)",
+        "abilities": [
+            "Pressure",
+            "Snow Cloak"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 85,
+            "defense": 100,
+            "sp.atk": 95,
+            "sp.def": 125,
+            "speed": 85,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "A legendary bird Pokemon. It can create blizzards by freezing moisture in the air.",
+        "gen": 1
+    },
+    "Zapdos": {
+        "id": "145",
+        "name": "Zapdos",
+        "species": "Electric Pokemon",
+        "type": [
+            "Electric",
+            "Flying"
+        ],
+        "height": "5ft.3in. (1.60m)",
+        "weight": "116 lbs (52.6 kg)",
+        "abilities": [
+            "Pressure",
+            "Lightning Rod"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 90,
+            "defense": 85,
+            "sp.atk": 125,
+            "sp.def": 90,
+            "speed": 100,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "A legendary Pokemon that is said to live in thunderclouds. It freely controls lightning bolts.",
+        "gen": 1
+    },
+    "Moltres": {
+        "id": "146",
+        "name": "Moltres",
+        "species": "Flame Pokemon",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "6ft.7in. (2.01m)",
+        "weight": "132.3 lbs (60.0 kg)",
+        "abilities": [
+            "Pressure",
+            "Flame Body"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 100,
+            "defense": 90,
+            "sp.atk": 125,
+            "sp.def": 85,
+            "speed": 90,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "One of the legendary bird Pokemon. It is said that its appearance indicates the coming of spring.",
+        "gen": 1
+    },
+    "Dratini": {
+        "id": "147",
+        "name": "Dratini",
+        "species": "Dragon Pokemon",
+        "type": [
+            "Dragon"
+        ],
+        "height": "5ft.11in. (1.80m)",
+        "weight": "7.3 lbs (3.3 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Marvel Scale"
+        ],
+        "stats": {
+            "hp": 41,
+            "attack": 64,
+            "defense": 45,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 50,
+            "total": 300
+        },
+        "evolution": [
+            "Dratini",
+            "Dragonair",
+            "Dragonite"
+        ],
+        "description": "It is called the Mirage Pokemon because so few have seen it. Its shed skin has been found.",
+        "gen": 1
+    },
+    "Dragonair": {
+        "id": "148",
+        "name": "Dragonair",
+        "species": "Dragon Pokemon",
+        "type": [
+            "Dragon"
+        ],
+        "height": "13ft.1in. (3.99m)",
+        "weight": "36.4 lbs (16.5 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Marvel Scale"
+        ],
+        "stats": {
+            "hp": 61,
+            "attack": 84,
+            "defense": 65,
+            "sp.atk": 70,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 420
+        },
+        "evolution": [
+            "Dratini",
+            "Dragonair",
+            "Dragonite"
+        ],
+        "description": "If its body takes on an aura, the weather changes instantly. It is said to live in seas and lakes.",
+        "gen": 1
+    },
+    "Dragonite": {
+        "id": "149",
+        "name": "Dragonite",
+        "species": "Dragon Pokemon",
+        "type": [
+            "Dragon",
+            "Flying"
+        ],
+        "height": "7ft.3in. (2.21m)",
+        "weight": "463 lbs (210.0 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Multiscale"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 134,
+            "defense": 95,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 80,
+            "total": 600
+        },
+        "evolution": [
+            "Dratini",
+            "Dragonair",
+            "Dragonite"
+        ],
+        "description": "It is said to make its home somewhere in the sea. It guides crews of shipwrecks to shore.",
+        "gen": 1
+    },
+    "Mewtwo": {
+        "id": "150",
+        "name": "Mewtwo",
+        "species": "Genetic Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "6ft.7in. (2.01m)",
+        "weight": "269 lbs (122.0 kg)",
+        "abilities": [
+            "Pressure",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 106,
+            "attack": 110,
+            "defense": 90,
+            "sp.atk": 154,
+            "sp.def": 90,
+            "speed": 130,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "A Pokemon created by recombining Mews genes. Its said to have the most savage heart among Pokmon.",
+        "gen": 1
+    },
+    "Mew": {
+        "id": "151",
+        "name": "Mew",
+        "species": "New Species Pokemon",
+        "type": [
+            "Psychic"
+        ],
+        "height": "1ft.4in. (0.41m)",
+        "weight": "8.8 lbs (4.0 kg)",
+        "abilities": [
+            "Synchronize"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Mew is said to possess the genetic composition of all Pokemon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.",
+        "gen": 1
+    },
+    "Chikorita": {
+        "name": "Chikorita",
+        "species": "Leaf Pokemon",
+        "id": "152",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.9m)",
+        "weight": "(6.4 kg)",
+        "abilities": [
+            "Overgrow",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 49,
+            "defense": 65,
+            "sp.atk": 49,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 318
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Bayleef": {
+        "name": "Bayleef",
+        "species": "Leaf Pokemon",
+        "id": "153",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.2m)",
+        "weight": "(15.8 kg)",
+        "abilities": [
+            "Overgrow",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 62,
+            "defense": 80,
+            "sp.atk": 63,
+            "sp.def": 80,
+            "speed": 60,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Meganium": {
+        "name": "Meganium",
+        "species": "Herb Pokemon",
+        "id": "154",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.8m)",
+        "weight": "(100.5 kg)",
+        "abilities": [
+            "Overgrow",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 82,
+            "defense": 100,
+            "sp.atk": 83,
+            "sp.def": 100,
+            "speed": 80,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Cyndaquil": {
+        "name": "Cyndaquil",
+        "species": "Fire Mouse Pokemon",
+        "id": "155",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.5m)",
+        "weight": "(7.9 kg)",
+        "abilities": [
+            "Blaze",
+            "Flash Fire"
+        ],
+        "stats": {
+            "hp": 39,
+            "attack": 52,
+            "defense": 43,
+            "sp.atk": 60,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 309
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Quilava": {
+        "name": "Quilava",
+        "species": "Volcano Pokemon",
+        "id": "156",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.9m)",
+        "weight": "(19 kg)",
+        "abilities": [
+            "Blaze",
+            "Flash Fire"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 64,
+            "defense": 58,
+            "sp.atk": 80,
+            "sp.def": 65,
+            "speed": 80,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Typhlosion": {
+        "name": "Typhlosion",
+        "species": "Volcano Pokemon",
+        "id": "157",
+        "type": [
+            "Fire"
+        ],
+        "height": "(1.7m)",
+        "weight": "(79.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Flash Fire"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 84,
+            "defense": 78,
+            "sp.atk": 109,
+            "sp.def": 85,
+            "speed": 100,
+            "total": 534
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Totodile": {
+        "name": "Totodile",
+        "species": "Big Jaw Pokemon",
+        "id": "158",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(9.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 65,
+            "defense": 64,
+            "sp.atk": 44,
+            "sp.def": 48,
+            "speed": 43,
+            "total": 314
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Croconaw": {
+        "name": "Croconaw",
+        "species": "Big Jaw Pokemon",
+        "id": "159",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.1m)",
+        "weight": "(25 kg)",
+        "abilities": [
+            "Torrent",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 80,
+            "defense": 80,
+            "sp.atk": 59,
+            "sp.def": 63,
+            "speed": 58,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Feraligatr": {
+        "name": "Feraligatr",
+        "species": "Big Jaw Pokemon",
+        "id": "160",
+        "type": [
+            "Water"
+        ],
+        "height": "(2.3m)",
+        "weight": "(88.8 kg)",
+        "abilities": [
+            "Torrent",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 105,
+            "defense": 100,
+            "sp.atk": 79,
+            "sp.def": 83,
+            "speed": 78,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Sentret": {
+        "name": "Sentret",
+        "species": "Scout Pokemon",
+        "id": "161",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.8m)",
+        "weight": "(6 kg)",
+        "abilities": [
+            "Run Away",
+            "Keen Eye",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 46,
+            "defense": 34,
+            "sp.atk": 35,
+            "sp.def": 45,
+            "speed": 20,
+            "total": 215
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Furret": {
+        "name": "Furret",
+        "species": "Long Body Pokemon",
+        "id": "162",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.8m)",
+        "weight": "(32.5 kg)",
+        "abilities": [
+            "Run Away",
+            "Keen Eye",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 76,
+            "defense": 64,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 90,
+            "total": 415
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Hoothoot": {
+        "name": "Hoothoot",
+        "species": "Owl Pokemon",
+        "id": "163",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.7m)",
+        "weight": "(21.2 kg)",
+        "abilities": [
+            "Insomnia",
+            "Keen Eye",
+            "Tinted Lens"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 30,
+            "defense": 30,
+            "sp.atk": 36,
+            "sp.def": 56,
+            "speed": 50,
+            "total": 262
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Noctowl": {
+        "name": "Noctowl",
+        "species": "Owl Pokemon",
+        "id": "164",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(1.6m)",
+        "weight": "(40.8 kg)",
+        "abilities": [
+            "Insomnia",
+            "Keen Eye",
+            "Tinted Lens"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 50,
+            "defense": 50,
+            "sp.atk": 86,
+            "sp.def": 96,
+            "speed": 70,
+            "total": 452
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ledyba": {
+        "name": "Ledyba",
+        "species": "Five Star Pokemon",
+        "id": "165",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1m)",
+        "weight": "(10.8 kg)",
+        "abilities": [
+            "Swarm",
+            "Early Bird",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 20,
+            "defense": 30,
+            "sp.atk": 40,
+            "sp.def": 80,
+            "speed": 55,
+            "total": 265
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ledian": {
+        "name": "Ledian",
+        "species": "Five Star Pokemon",
+        "id": "166",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1.4m)",
+        "weight": "(35.6 kg)",
+        "abilities": [
+            "Swarm",
+            "Early Bird",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 35,
+            "defense": 50,
+            "sp.atk": 55,
+            "sp.def": 110,
+            "speed": 85,
+            "total": 390
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Spinarak": {
+        "name": "Spinarak",
+        "species": "String Spit Pokemon",
+        "id": "167",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(0.5m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Insomnia",
+            "Sniper"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 60,
+            "defense": 40,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 30,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ariados": {
+        "name": "Ariados",
+        "species": "Long Leg Pokemon",
+        "id": "168",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(1.1m)",
+        "weight": "(33.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Insomnia",
+            "Sniper"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 90,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 40,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Crobat": {
+        "name": "Crobat",
+        "species": "Bat Pokemon",
+        "id": "169",
+        "type": [
+            "Poison",
+            "Flying"
+        ],
+        "height": "(1.8m)",
+        "weight": "(75 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 90,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 80,
+            "speed": 130,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Chinchou": {
+        "name": "Chinchou",
+        "species": "Angler Pokemon",
+        "id": "170",
+        "type": [
+            "Water",
+            "Electric"
+        ],
+        "height": "(0.5m)",
+        "weight": "(12 kg)",
+        "abilities": [
+            "Volt Absorb",
+            "Illuminate",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 38,
+            "defense": 38,
+            "sp.atk": 56,
+            "sp.def": 56,
+            "speed": 67,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Lanturn": {
+        "name": "Lanturn",
+        "species": "Light Pokemon",
+        "id": "171",
+        "type": [
+            "Water",
+            "Electric"
+        ],
+        "height": "(1.2m)",
+        "weight": "(22.5 kg)",
+        "abilities": [
+            "Volt Absorb",
+            "Illuminate",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 125,
+            "attack": 58,
+            "defense": 58,
+            "sp.atk": 76,
+            "sp.def": 76,
+            "speed": 67,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Pichu": {
+        "name": "Pichu",
+        "species": "Tiny Mouse Pokemon",
+        "id": "172",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "Static",
+            "Lightningrod"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 40,
+            "defense": 15,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 60,
+            "total": 205
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Cleffa": {
+        "name": "Cleffa",
+        "species": "Star Shape Pokemon",
+        "id": "173",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Magic Guard",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 25,
+            "defense": 28,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 15,
+            "total": 218
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Igglybuff": {
+        "name": "Igglybuff",
+        "species": "Balloon Pokemon",
+        "id": "174",
+        "type": [
+            "Normal",
+            "Fairy"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Competitive",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 30,
+            "defense": 15,
+            "sp.atk": 40,
+            "sp.def": 20,
+            "speed": 15,
+            "total": 210
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Togepi": {
+        "name": "Togepi",
+        "species": "Spike Ball Pokemon",
+        "id": "175",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.5 kg)",
+        "abilities": [
+            "Hustle",
+            "Serene Grace",
+            "Super Luck"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 20,
+            "defense": 65,
+            "sp.atk": 40,
+            "sp.def": 65,
+            "speed": 20,
+            "total": 245
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Togetic": {
+        "name": "Togetic",
+        "species": "Happiness Pokemon",
+        "id": "176",
+        "type": [
+            "Fairy",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(3.2 kg)",
+        "abilities": [
+            "Hustle",
+            "Serene Grace",
+            "Super Luck"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 40,
+            "defense": 85,
+            "sp.atk": 80,
+            "sp.def": 105,
+            "speed": 40,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Natu": {
+        "name": "Natu",
+        "species": "Little Bird Pokemon",
+        "id": "177",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(0.2m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "Synchronize",
+            "Early Bird",
+            "Magic Bounce"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 50,
+            "defense": 45,
+            "sp.atk": 70,
+            "sp.def": 45,
+            "speed": 70,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Xatu": {
+        "name": "Xatu",
+        "species": "Mystic Pokemon",
+        "id": "178",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Synchronize",
+            "Early Bird",
+            "Magic Bounce"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 75,
+            "defense": 70,
+            "sp.atk": 95,
+            "sp.def": 70,
+            "speed": 95,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Mareep": {
+        "name": "Mareep",
+        "species": "Wool Pokemon",
+        "id": "179",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.6m)",
+        "weight": "(7.8 kg)",
+        "abilities": [
+            "Static",
+            "Plus"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 40,
+            "defense": 40,
+            "sp.atk": 65,
+            "sp.def": 45,
+            "speed": 35,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Flaaffy": {
+        "name": "Flaaffy",
+        "species": "Wool Pokemon",
+        "id": "180",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.8m)",
+        "weight": "(13.3 kg)",
+        "abilities": [
+            "Static",
+            "Plus"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 55,
+            "defense": 55,
+            "sp.atk": 80,
+            "sp.def": 60,
+            "speed": 45,
+            "total": 365
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ampharos": {
+        "name": "Ampharos",
+        "species": "Light Pokemon",
+        "id": "181",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.4m)",
+        "weight": "(61.5 kg)",
+        "abilities": [
+            "Static",
+            "Plus"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 95,
+            "defense": 105,
+            "sp.atk": 165,
+            "sp.def": 110,
+            "speed": 45,
+            "total": 610
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Bellossom": {
+        "name": "Bellossom",
+        "species": "Flower Pokemon",
+        "id": "182",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.8 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Healer"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 80,
+            "defense": 95,
+            "sp.atk": 90,
+            "sp.def": 100,
+            "speed": 50,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Marill": {
+        "name": "Marill",
+        "species": "Aquamouse Pokemon",
+        "id": "183",
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "height": "(0.4m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Huge Power",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 20,
+            "defense": 50,
+            "sp.atk": 20,
+            "sp.def": 50,
+            "speed": 40,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Azumarill": {
+        "name": "Azumarill",
+        "species": "Aquarabbit Pokemon",
+        "id": "184",
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "height": "(0.8m)",
+        "weight": "(28.5 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Huge Power",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 50,
+            "defense": 80,
+            "sp.atk": 60,
+            "sp.def": 80,
+            "speed": 50,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Sudowoodo": {
+        "name": "Sudowoodo",
+        "species": "Imitation Pokemon",
+        "id": "185",
+        "type": [
+            "Rock"
+        ],
+        "height": "(1.2m)",
+        "weight": "(38 kg)",
+        "abilities": [
+            "Sturdy",
+            "Rock Head",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 100,
+            "defense": 115,
+            "sp.atk": 30,
+            "sp.def": 65,
+            "speed": 30,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Politoed": {
+        "name": "Politoed",
+        "species": "Frog Pokemon",
+        "id": "186",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.1m)",
+        "weight": "(33.9 kg)",
+        "abilities": [
+            "Water Absorb",
+            "Damp",
+            "Drizzle"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 75,
+            "defense": 75,
+            "sp.atk": 90,
+            "sp.def": 100,
+            "speed": 70,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Hoppip": {
+        "name": "Hoppip",
+        "species": "Cottonweed Pokemon",
+        "id": "187",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(0.4m)",
+        "weight": "(0.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Leaf Guard",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 35,
+            "defense": 40,
+            "sp.atk": 35,
+            "sp.def": 55,
+            "speed": 50,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Skiploom": {
+        "name": "Skiploom",
+        "species": "Cottonweed Pokemon",
+        "id": "188",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Leaf Guard",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 45,
+            "defense": 50,
+            "sp.atk": 45,
+            "sp.def": 65,
+            "speed": 80,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Jumpluff": {
+        "name": "Jumpluff",
+        "species": "Cottonweed Pokemon",
+        "id": "189",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(0.8m)",
+        "weight": "(3 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Leaf Guard",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 55,
+            "defense": 70,
+            "sp.atk": 55,
+            "sp.def": 95,
+            "speed": 110,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Aipom": {
+        "name": "Aipom",
+        "species": "Long Tail Pokemon",
+        "id": "190",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.8m)",
+        "weight": "(11.5 kg)",
+        "abilities": [
+            "Run Away",
+            "Pickup",
+            "Skill Link"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 70,
+            "defense": 55,
+            "sp.atk": 40,
+            "sp.def": 55,
+            "speed": 85,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Sunkern": {
+        "name": "Sunkern",
+        "species": "Seed Pokemon",
+        "id": "191",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.8 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Solar Power",
+            "Early Bird"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 30,
+            "defense": 30,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 30,
+            "total": 180
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Sunflora": {
+        "name": "Sunflora",
+        "species": "Sun Pokemon",
+        "id": "192",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.8m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Solar Power",
+            "Early Bird"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 75,
+            "defense": 55,
+            "sp.atk": 105,
+            "sp.def": 85,
+            "speed": 30,
+            "total": 425
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Yanma": {
+        "name": "Yanma",
+        "species": "Clear Wing Pokemon",
+        "id": "193",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(38 kg)",
+        "abilities": [
+            "Speed Boost",
+            "Compoundeyes",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 65,
+            "defense": 45,
+            "sp.atk": 75,
+            "sp.def": 45,
+            "speed": 95,
+            "total": 390
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Wooper": {
+        "name": "Wooper",
+        "species": "Water Fish Pokemon",
+        "id": "194",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.4m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Damp",
+            "Water Absorb",
+            "Unaware"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 45,
+            "defense": 45,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 15,
+            "total": 210
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Quagsire": {
+        "name": "Quagsire",
+        "species": "Water Fish Pokemon",
+        "id": "195",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(1.4m)",
+        "weight": "(75 kg)",
+        "abilities": [
+            "Damp",
+            "Water Absorb",
+            "Unaware"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 85,
+            "defense": 85,
+            "sp.atk": 65,
+            "sp.def": 65,
+            "speed": 35,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Espeon": {
+        "name": "Espeon",
+        "species": "Sun Pokemon",
+        "id": "196",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.9m)",
+        "weight": "(26.5 kg)",
+        "abilities": [
+            "Synchronize",
+            "Magic Bounce"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 65,
+            "defense": 60,
+            "sp.atk": 130,
+            "sp.def": 95,
+            "speed": 110,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Umbreon": {
+        "name": "Umbreon",
+        "species": "Moonlight Pokemon",
+        "id": "197",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(27 kg)",
+        "abilities": [
+            "Synchronize",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 65,
+            "defense": 110,
+            "sp.atk": 60,
+            "sp.def": 130,
+            "speed": 65,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Murkrow": {
+        "name": "Murkrow",
+        "species": "Darkness Pokemon",
+        "id": "198",
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(2.1 kg)",
+        "abilities": [
+            "Insomnia",
+            "Super Luck",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 42,
+            "sp.atk": 85,
+            "sp.def": 42,
+            "speed": 91,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Slowking": {
+        "name": "Slowking",
+        "species": "Royal Pokemon",
+        "id": "199",
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "height": "(2m)",
+        "weight": "(79.5 kg)",
+        "abilities": [
+            "Oblivious",
+            "Own Tempo",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 75,
+            "defense": 80,
+            "sp.atk": 100,
+            "sp.def": 110,
+            "speed": 30,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Misdreavus": {
+        "name": "Misdreavus",
+        "species": "Screech Pokemon",
+        "id": "200",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(0.7m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 85,
+            "sp.def": 85,
+            "speed": 85,
+            "total": 435
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Unown": {
+        "name": "Unown",
+        "species": "Symbol Pokemon",
+        "id": "201",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 48,
+            "attack": 72,
+            "defense": 48,
+            "sp.atk": 72,
+            "sp.def": 48,
+            "speed": 48,
+            "total": 336
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Wobbuffet": {
+        "name": "Wobbuffet",
+        "species": "Patient Pokemon",
+        "id": "202",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1.3m)",
+        "weight": "(28.5 kg)",
+        "abilities": [
+            "Shadow Tag",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 190,
+            "attack": 33,
+            "defense": 58,
+            "sp.atk": 33,
+            "sp.def": 58,
+            "speed": 33,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Girafarig": {
+        "name": "Girafarig",
+        "species": "Long Neck Pokemon",
+        "id": "203",
+        "type": [
+            "Normal",
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(41.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Early Bird",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 80,
+            "defense": 65,
+            "sp.atk": 90,
+            "sp.def": 65,
+            "speed": 85,
+            "total": 455
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Pineco": {
+        "name": "Pineco",
+        "species": "Bagworm Pokemon",
+        "id": "204",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.6m)",
+        "weight": "(7.2 kg)",
+        "abilities": [
+            "Sturdy",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 65,
+            "defense": 90,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 15,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Forretress": {
+        "name": "Forretress",
+        "species": "Bagworm Pokemon",
+        "id": "205",
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "height": "(1.2m)",
+        "weight": "(125.8 kg)",
+        "abilities": [
+            "Sturdy",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 90,
+            "defense": 140,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 40,
+            "total": 465
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Dunsparce": {
+        "name": "Dunsparce",
+        "species": "Land Snake Pokemon",
+        "id": "206",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.5m)",
+        "weight": "(14 kg)",
+        "abilities": [
+            "Serene Grace",
+            "Run Away",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 70,
+            "defense": 70,
+            "sp.atk": 65,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 415
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Gligar": {
+        "name": "Gligar",
+        "species": "Flyscorpion Pokemon",
+        "id": "207",
+        "type": [
+            "Ground",
+            "Flying"
+        ],
+        "height": "(1.1m)",
+        "weight": "(64.8 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Sand Veil",
+            "Immunity"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 75,
+            "defense": 105,
+            "sp.atk": 35,
+            "sp.def": 65,
+            "speed": 85,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Steelix": {
+        "name": "Steelix",
+        "species": "Iron Snake Pokemon",
+        "id": "208",
+        "type": [
+            "Steel",
+            "Ground"
+        ],
+        "height": "(9.2m)",
+        "weight": "(400 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sturdy",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 125,
+            "defense": 230,
+            "sp.atk": 55,
+            "sp.def": 95,
+            "speed": 30,
+            "total": 610
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Snubbull": {
+        "name": "Snubbull",
+        "species": "Fairy Pokemon",
+        "id": "209",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.6m)",
+        "weight": "(7.8 kg)",
+        "abilities": [
+            "Intimidate",
+            "Run Away",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 80,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 30,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Granbull": {
+        "name": "Granbull",
+        "species": "Fairy Pokemon",
+        "id": "210",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(1.4m)",
+        "weight": "(48.7 kg)",
+        "abilities": [
+            "Intimidate",
+            "Quick Feet",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 120,
+            "defense": 75,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 45,
+            "total": 450
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Qwilfish": {
+        "name": "Qwilfish",
+        "species": "Balloon Pokemon",
+        "id": "211",
+        "type": [
+            "Water",
+            "Poison"
+        ],
+        "height": "(0.5m)",
+        "weight": "(3.9 kg)",
+        "abilities": [
+            "Poison Point",
+            "Swift Swim",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 95,
+            "defense": 85,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 85,
+            "total": 440
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Scizor": {
+        "name": "Scizor",
+        "species": "Pincer Pokemon",
+        "id": "212",
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "height": "(1.8m)",
+        "weight": "(118 kg)",
+        "abilities": [
+            "Swarm",
+            "Technician",
+            "Light Metal"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 150,
+            "defense": 140,
+            "sp.atk": 65,
+            "sp.def": 100,
+            "speed": 75,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Shuckle": {
+        "name": "Shuckle",
+        "species": "Mold Pokemon",
+        "id": "213",
+        "type": [
+            "Bug",
+            "Rock"
+        ],
+        "height": "(0.6m)",
+        "weight": "(20.5 kg)",
+        "abilities": [
+            "Sturdy",
+            "Gluttony",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 10,
+            "defense": 230,
+            "sp.atk": 10,
+            "sp.def": 230,
+            "speed": 5,
+            "total": 505
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Heracross": {
+        "name": "Heracross",
+        "species": "Singlehorn Pokemon",
+        "id": "214",
+        "type": [
+            "Bug",
+            "Fighting"
+        ],
+        "height": "(1.5m)",
+        "weight": "(54 kg)",
+        "abilities": [
+            "Swarm",
+            "Guts",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 185,
+            "defense": 115,
+            "sp.atk": 40,
+            "sp.def": 105,
+            "speed": 75,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Sneasel": {
+        "name": "Sneasel",
+        "species": "Sharp Claw Pokemon",
+        "id": "215",
+        "type": [
+            "Dark",
+            "Ice"
+        ],
+        "height": "(0.9m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Keen Eye",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 95,
+            "defense": 55,
+            "sp.atk": 35,
+            "sp.def": 75,
+            "speed": 115,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Teddiursa": {
+        "name": "Teddiursa",
+        "species": "Little Bear Pokemon",
+        "id": "216",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8.8 kg)",
+        "abilities": [
+            "Pickup",
+            "Quick Feet",
+            "Honey Gather"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 80,
+            "defense": 50,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 40,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ursaring": {
+        "name": "Ursaring",
+        "species": "Hibernator Pokemon",
+        "id": "217",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.8m)",
+        "weight": "(125.8 kg)",
+        "abilities": [
+            "Guts",
+            "Quick Feet",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 130,
+            "defense": 75,
+            "sp.atk": 75,
+            "sp.def": 75,
+            "speed": 55,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Slugma": {
+        "name": "Slugma",
+        "species": "Lava Pokemon",
+        "id": "218",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.7m)",
+        "weight": "(35 kg)",
+        "abilities": [
+            "Magma Armor",
+            "Flame Body",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 40,
+            "defense": 40,
+            "sp.atk": 70,
+            "sp.def": 40,
+            "speed": 20,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Magcargo": {
+        "name": "Magcargo",
+        "species": "Lava Pokemon",
+        "id": "219",
+        "type": [
+            "Fire",
+            "Rock"
+        ],
+        "height": "(0.8m)",
+        "weight": "(55 kg)",
+        "abilities": [
+            "Magma Armor",
+            "Flame Body",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 120,
+            "sp.atk": 90,
+            "sp.def": 80,
+            "speed": 30,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Swinub": {
+        "name": "Swinub",
+        "species": "Pig Pokemon",
+        "id": "220",
+        "type": [
+            "Ice",
+            "Ground"
+        ],
+        "height": "(0.4m)",
+        "weight": "(6.5 kg)",
+        "abilities": [
+            "Oblivious",
+            "Snow Cloak",
+            "Thick Fat"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 40,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 50,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Piloswine": {
+        "name": "Piloswine",
+        "species": "Swine Pokemon",
+        "id": "221",
+        "type": [
+            "Ice",
+            "Ground"
+        ],
+        "height": "(1.1m)",
+        "weight": "(55.8 kg)",
+        "abilities": [
+            "Oblivious",
+            "Snow Cloak",
+            "Thick Fat"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 80,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 50,
+            "total": 450
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Corsola": {
+        "name": "Corsola",
+        "species": "Coral Pokemon",
+        "id": "222",
+        "type": [
+            "Water",
+            "Rock"
+        ],
+        "height": "(0.6m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Hustle",
+            "Natural Cure",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 55,
+            "defense": 95,
+            "sp.atk": 65,
+            "sp.def": 95,
+            "speed": 35,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Remoraid": {
+        "name": "Remoraid",
+        "species": "Jet Pokemon",
+        "id": "223",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(12 kg)",
+        "abilities": [
+            "Hustle",
+            "Sniper",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 65,
+            "defense": 35,
+            "sp.atk": 65,
+            "sp.def": 35,
+            "speed": 65,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Octillery": {
+        "name": "Octillery",
+        "species": "Jet Pokemon",
+        "id": "224",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.9m)",
+        "weight": "(28.5 kg)",
+        "abilities": [
+            "Suction Cups",
+            "Sniper",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 105,
+            "defense": 75,
+            "sp.atk": 105,
+            "sp.def": 75,
+            "speed": 45,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Delibird": {
+        "name": "Delibird",
+        "species": "Delivery Pokemon",
+        "id": "225",
+        "type": [
+            "Ice",
+            "Flying"
+        ],
+        "height": "(0.9m)",
+        "weight": "(16 kg)",
+        "abilities": [
+            "Vital Spirit",
+            "Hustle",
+            "Insomnia"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 55,
+            "defense": 45,
+            "sp.atk": 65,
+            "sp.def": 45,
+            "speed": 75,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Mantine": {
+        "name": "Mantine",
+        "species": "Kite Pokemon",
+        "id": "226",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(2.1m)",
+        "weight": "(220 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Absorb",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 40,
+            "defense": 70,
+            "sp.atk": 80,
+            "sp.def": 140,
+            "speed": 70,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Skarmory": {
+        "name": "Skarmory",
+        "species": "Armor Bird Pokemon",
+        "id": "227",
+        "type": [
+            "Steel",
+            "Flying"
+        ],
+        "height": "(1.7m)",
+        "weight": "(50.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sturdy",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 80,
+            "defense": 140,
+            "sp.atk": 40,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 465
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Houndour": {
+        "name": "Houndour",
+        "species": "Dark Pokemon",
+        "id": "228",
+        "type": [
+            "Dark",
+            "Fire"
+        ],
+        "height": "(0.6m)",
+        "weight": "(10.8 kg)",
+        "abilities": [
+            "Early Bird",
+            "Flash Fire",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 60,
+            "defense": 30,
+            "sp.atk": 80,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Houndoom": {
+        "name": "Houndoom",
+        "species": "Dark Pokemon",
+        "id": "229",
+        "type": [
+            "Dark",
+            "Fire"
+        ],
+        "height": "(1.4m)",
+        "weight": "(35 kg)",
+        "abilities": [
+            "Early Bird",
+            "Flash Fire",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 90,
+            "defense": 90,
+            "sp.atk": 140,
+            "sp.def": 90,
+            "speed": 115,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Kingdra": {
+        "name": "Kingdra",
+        "species": "Dragon Pokemon",
+        "id": "230",
+        "type": [
+            "Water",
+            "Dragon"
+        ],
+        "height": "(1.8m)",
+        "weight": "(152 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Sniper",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 95,
+            "defense": 95,
+            "sp.atk": 95,
+            "sp.def": 95,
+            "speed": 85,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Phanpy": {
+        "name": "Phanpy",
+        "species": "Long Nose Pokemon",
+        "id": "231",
+        "type": [
+            "Ground"
+        ],
+        "height": "(0.5m)",
+        "weight": "(33.5 kg)",
+        "abilities": [
+            "Pickup",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 40,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Donphan": {
+        "name": "Donphan",
+        "species": "Armor Pokemon",
+        "id": "232",
+        "type": [
+            "Ground"
+        ],
+        "height": "(1.1m)",
+        "weight": "(120 kg)",
+        "abilities": [
+            "Sturdy",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 120,
+            "defense": 120,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 50,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Porygon2": {
+        "name": "Porygon2",
+        "species": "Virtual Pokemon",
+        "id": "233",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(32.5 kg)",
+        "abilities": [
+            "Trace",
+            "Download",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 80,
+            "defense": 90,
+            "sp.atk": 105,
+            "sp.def": 95,
+            "speed": 60,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Stantler": {
+        "name": "Stantler",
+        "species": "Big Horn Pokemon",
+        "id": "234",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.4m)",
+        "weight": "(71.2 kg)",
+        "abilities": [
+            "Intimidate",
+            "Frisk",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 73,
+            "attack": 95,
+            "defense": 62,
+            "sp.atk": 85,
+            "sp.def": 65,
+            "speed": 85,
+            "total": 465
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Smeargle": {
+        "name": "Smeargle",
+        "species": "Painter Pokemon",
+        "id": "235",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(58 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Technician",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 20,
+            "defense": 35,
+            "sp.atk": 20,
+            "sp.def": 45,
+            "speed": 75,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Tyrogue": {
+        "name": "Tyrogue",
+        "species": "Scuffle Pokemon",
+        "id": "236",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.7m)",
+        "weight": "(21 kg)",
+        "abilities": [
+            "Guts",
+            "Steadfast",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 35,
+            "defense": 35,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 35,
+            "total": 210
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Hitmontop": {
+        "name": "Hitmontop",
+        "species": "Handstand Pokemon",
+        "id": "237",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.4m)",
+        "weight": "(48 kg)",
+        "abilities": [
+            "Intimidate",
+            "Technician",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 95,
+            "defense": 95,
+            "sp.atk": 35,
+            "sp.def": 110,
+            "speed": 70,
+            "total": 455
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Smoochum": {
+        "name": "Smoochum",
+        "species": "Kiss Pokemon",
+        "id": "238",
+        "type": [
+            "Ice",
+            "Psychic"
+        ],
+        "height": "(0.4m)",
+        "weight": "(6 kg)",
+        "abilities": [
+            "Oblivious",
+            "Forewarn",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 30,
+            "defense": 15,
+            "sp.atk": 85,
+            "sp.def": 65,
+            "speed": 65,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Elekid": {
+        "name": "Elekid",
+        "species": "Electric Pokemon",
+        "id": "239",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.6m)",
+        "weight": "(23.5 kg)",
+        "abilities": [
+            "Static",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 63,
+            "defense": 37,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 95,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Magby": {
+        "name": "Magby",
+        "species": "Live Coal Pokemon",
+        "id": "240",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.7m)",
+        "weight": "(21.4 kg)",
+        "abilities": [
+            "Flame Body",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 75,
+            "defense": 37,
+            "sp.atk": 70,
+            "sp.def": 55,
+            "speed": 83,
+            "total": 365
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Miltank": {
+        "name": "Miltank",
+        "species": "Milk Cow Pokemon",
+        "id": "241",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(75.5 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Scrappy",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 80,
+            "defense": 105,
+            "sp.atk": 40,
+            "sp.def": 70,
+            "speed": 100,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Blissey": {
+        "name": "Blissey",
+        "species": "Happiness Pokemon",
+        "id": "242",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.5m)",
+        "weight": "(46.8 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Serene Grace",
+            "Healer"
+        ],
+        "stats": {
+            "hp": 255,
+            "attack": 10,
+            "defense": 10,
+            "sp.atk": 75,
+            "sp.def": 135,
+            "speed": 55,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Raikou": {
+        "name": "Raikou",
+        "species": "Thunder Pokemon",
+        "id": "243",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.9m)",
+        "weight": "(178 kg)",
+        "abilities": [
+            "Pressure",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 85,
+            "defense": 75,
+            "sp.atk": 115,
+            "sp.def": 100,
+            "speed": 115,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Entei": {
+        "name": "Entei",
+        "species": "Volcano Pokemon",
+        "id": "244",
+        "type": [
+            "Fire"
+        ],
+        "height": "(2.1m)",
+        "weight": "(198 kg)",
+        "abilities": [
+            "Pressure",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 115,
+            "attack": 115,
+            "defense": 85,
+            "sp.atk": 90,
+            "sp.def": 75,
+            "speed": 100,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Suicune": {
+        "name": "Suicune",
+        "species": "Aurora Pokemon",
+        "id": "245",
+        "type": [
+            "Water"
+        ],
+        "height": "(2m)",
+        "weight": "(187 kg)",
+        "abilities": [
+            "Pressure",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 75,
+            "defense": 115,
+            "sp.atk": 90,
+            "sp.def": 115,
+            "speed": 85,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Larvitar": {
+        "name": "Larvitar",
+        "species": "Rock Skin Pokemon",
+        "id": "246",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "(0.6m)",
+        "weight": "(72 kg)",
+        "abilities": [
+            "Guts",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 64,
+            "defense": 50,
+            "sp.atk": 45,
+            "sp.def": 50,
+            "speed": 41,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Pupitar": {
+        "name": "Pupitar",
+        "species": "Hard Shell Pokemon",
+        "id": "247",
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "height": "(1.2m)",
+        "weight": "(152 kg)",
+        "abilities": [
+            "Shed Skin"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 84,
+            "defense": 70,
+            "sp.atk": 65,
+            "sp.def": 70,
+            "speed": 51,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Tyranitar": {
+        "name": "Tyranitar",
+        "species": "Armor Pokemon",
+        "id": "248",
+        "type": [
+            "Rock",
+            "Dark"
+        ],
+        "height": "(2m)",
+        "weight": "(202 kg)",
+        "abilities": [
+            "Sand Stream",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 164,
+            "defense": 150,
+            "sp.atk": 95,
+            "sp.def": 120,
+            "speed": 71,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Lugia": {
+        "name": "Lugia",
+        "species": "Diving Pokemon",
+        "id": "249",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(5.2m)",
+        "weight": "(216 kg)",
+        "abilities": [
+            "Pressure",
+            "Multiscale"
+        ],
+        "stats": {
+            "hp": 106,
+            "attack": 90,
+            "defense": 130,
+            "sp.atk": 90,
+            "sp.def": 154,
+            "speed": 110,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Ho-Oh": {
+        "name": "Ho-Oh",
+        "species": "Rainbow Pokemon",
+        "id": "250",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "(3.8m)",
+        "weight": "(199 kg)",
+        "abilities": [
+            "Pressure",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 106,
+            "attack": 130,
+            "defense": 90,
+            "sp.atk": 110,
+            "sp.def": 154,
+            "speed": 90,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Celebi": {
+        "name": "Celebi",
+        "species": "Time Travel Pokemon",
+        "id": "251",
+        "type": [
+            "Psychic",
+            "Grass"
+        ],
+        "height": "(0.6m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Natural Cure"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 2
+    },
+    "Treecko": {
+        "name": "Treecko",
+        "species": "Wood Gecko Pokemon",
+        "id": "252",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Overgrow",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 35,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 70,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Grovyle": {
+        "name": "Grovyle",
+        "species": "Wood Gecko Pokemon",
+        "id": "253",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.9m)",
+        "weight": "(21.6 kg)",
+        "abilities": [
+            "Overgrow",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 65,
+            "defense": 45,
+            "sp.atk": 85,
+            "sp.def": 65,
+            "speed": 95,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Sceptile": {
+        "name": "Sceptile",
+        "species": "Forest Pokemon",
+        "id": "254",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.7m)",
+        "weight": "(52.2 kg)",
+        "abilities": [
+            "Overgrow",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 110,
+            "defense": 75,
+            "sp.atk": 145,
+            "sp.def": 85,
+            "speed": 145,
+            "total": 630
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Torchic": {
+        "name": "Torchic",
+        "species": "Chick Pokemon",
+        "id": "255",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.4m)",
+        "weight": "(2.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 60,
+            "defense": 40,
+            "sp.atk": 70,
+            "sp.def": 50,
+            "speed": 45,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Combusken": {
+        "name": "Combusken",
+        "species": "Young Fowl Pokemon",
+        "id": "256",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(0.9m)",
+        "weight": "(19.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 60,
+            "sp.atk": 85,
+            "sp.def": 60,
+            "speed": 55,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Blaziken": {
+        "name": "Blaziken",
+        "species": "Blaze Pokemon",
+        "id": "257",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(1.9m)",
+        "weight": "(52 kg)",
+        "abilities": [
+            "Blaze",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 160,
+            "defense": 80,
+            "sp.atk": 130,
+            "sp.def": 80,
+            "speed": 100,
+            "total": 630
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Mudkip": {
+        "name": "Mudkip",
+        "species": "Mud Fish Pokemon",
+        "id": "258",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(7.6 kg)",
+        "abilities": [
+            "Torrent",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 70,
+            "defense": 50,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 40,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Marshtomp": {
+        "name": "Marshtomp",
+        "species": "Mud Fish Pokemon",
+        "id": "259",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.7m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Torrent",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 85,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 50,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Swampert": {
+        "name": "Swampert",
+        "species": "Mud Fish Pokemon",
+        "id": "260",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(1.5m)",
+        "weight": "(81.9 kg)",
+        "abilities": [
+            "Torrent",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 150,
+            "defense": 110,
+            "sp.atk": 95,
+            "sp.def": 110,
+            "speed": 70,
+            "total": 635
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Poochyena": {
+        "name": "Poochyena",
+        "species": "Bite Pokemon",
+        "id": "261",
+        "type": [
+            "Dark"
+        ],
+        "height": "(0.5m)",
+        "weight": "(13.6 kg)",
+        "abilities": [
+            "Run Away",
+            "Quick Feet",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 55,
+            "defense": 35,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 35,
+            "total": 220
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Mightyena": {
+        "name": "Mightyena",
+        "species": "Bite Pokemon",
+        "id": "262",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(37 kg)",
+        "abilities": [
+            "Intimidate",
+            "Quick Feet",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 90,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 70,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Zigzagoon": {
+        "name": "Zigzagoon",
+        "species": "Tiny Racoon Pokemon",
+        "id": "263",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(17.5 kg)",
+        "abilities": [
+            "Pickup",
+            "Gluttony",
+            "Quick Feet"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 30,
+            "defense": 41,
+            "sp.atk": 30,
+            "sp.def": 41,
+            "speed": 60,
+            "total": 240
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Linoone": {
+        "name": "Linoone",
+        "species": "Rush Pokemon",
+        "id": "264",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(32.5 kg)",
+        "abilities": [
+            "Pickup",
+            "Gluttony",
+            "Quick Feet"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 70,
+            "defense": 61,
+            "sp.atk": 50,
+            "sp.def": 61,
+            "speed": 100,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Wurmple": {
+        "name": "Wurmple",
+        "species": "Worm Pokemon",
+        "id": "265",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3.6 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 45,
+            "defense": 35,
+            "sp.atk": 20,
+            "sp.def": 30,
+            "speed": 20,
+            "total": 195
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Silcoon": {
+        "name": "Silcoon",
+        "species": "Cocoon Pokemon",
+        "id": "266",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.6m)",
+        "weight": "(10 kg)",
+        "abilities": [
+            "Shed Skin"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 35,
+            "defense": 55,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 15,
+            "total": 205
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Beautifly": {
+        "name": "Beautifly",
+        "species": "Butterfly Pokemon",
+        "id": "267",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1m)",
+        "weight": "(28.4 kg)",
+        "abilities": [
+            "Swarm",
+            "Rivalry"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 70,
+            "defense": 50,
+            "sp.atk": 100,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 395
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Cascoon": {
+        "name": "Cascoon",
+        "species": "Cocoon Pokemon",
+        "id": "268",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.7m)",
+        "weight": "(11.5 kg)",
+        "abilities": [
+            "Shed Skin"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 35,
+            "defense": 55,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 15,
+            "total": 205
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Dustox": {
+        "name": "Dustox",
+        "species": "Poison Moth Pokemon",
+        "id": "269",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(1.2m)",
+        "weight": "(31.6 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Compoundeyes"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 70,
+            "sp.atk": 50,
+            "sp.def": 90,
+            "speed": 65,
+            "total": 385
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Lotad": {
+        "name": "Lotad",
+        "species": "Water Weed Pokemon",
+        "id": "270",
+        "type": [
+            "Water",
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(2.6 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rain Dish",
+            "Own Tempo"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 30,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 30,
+            "total": 220
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Lombre": {
+        "name": "Lombre",
+        "species": "Jolly Pokemon",
+        "id": "271",
+        "type": [
+            "Water",
+            "Grass"
+        ],
+        "height": "(1.2m)",
+        "weight": "(32.5 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rain Dish",
+            "Own Tempo"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 50,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 50,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Ludicolo": {
+        "name": "Ludicolo",
+        "species": "Carefree Pokemon",
+        "id": "272",
+        "type": [
+            "Water",
+            "Grass"
+        ],
+        "height": "(1.5m)",
+        "weight": "(55 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rain Dish",
+            "Own Tempo"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 70,
+            "defense": 70,
+            "sp.atk": 90,
+            "sp.def": 100,
+            "speed": 70,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Seedot": {
+        "name": "Seedot",
+        "species": "Acorn Pokemon",
+        "id": "273",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(4 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Early Bird",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 40,
+            "defense": 50,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 30,
+            "total": 220
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Nuzleaf": {
+        "name": "Nuzleaf",
+        "species": "Wily Pokemon",
+        "id": "274",
+        "type": [
+            "Grass",
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Early Bird",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 70,
+            "defense": 40,
+            "sp.atk": 60,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Shiftry": {
+        "name": "Shiftry",
+        "species": "Wickid Pokemon",
+        "id": "275",
+        "type": [
+            "Grass",
+            "Dark"
+        ],
+        "height": "(1.3m)",
+        "weight": "(59.6 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Early Bird",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 100,
+            "defense": 60,
+            "sp.atk": 90,
+            "sp.def": 60,
+            "speed": 80,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Taillow": {
+        "name": "Taillow",
+        "species": "TinySwallow Pokemon",
+        "id": "276",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.3 kg)",
+        "abilities": [
+            "Guts",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 30,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 85,
+            "total": 270
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Swellow": {
+        "name": "Swellow",
+        "species": "Swallow Pokemon",
+        "id": "277",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.7m)",
+        "weight": "(19.8 kg)",
+        "abilities": [
+            "Guts",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 60,
+            "sp.atk": 75,
+            "sp.def": 50,
+            "speed": 125,
+            "total": 455
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Wingull": {
+        "name": "Wingull",
+        "species": "Seagull Pokemon",
+        "id": "278",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(9.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Hydration",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 30,
+            "sp.atk": 55,
+            "sp.def": 30,
+            "speed": 85,
+            "total": 270
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Pelipper": {
+        "name": "Pelipper",
+        "species": "Water Bird Pokemon",
+        "id": "279",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Drizzle",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 100,
+            "sp.atk": 95,
+            "sp.def": 70,
+            "speed": 65,
+            "total": 440
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Ralts": {
+        "name": "Ralts",
+        "species": "Feeling Pokemon",
+        "id": "280",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "(0.4m)",
+        "weight": "(6.6 kg)",
+        "abilities": [
+            "Synchronize",
+            "Trace",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 28,
+            "attack": 25,
+            "defense": 25,
+            "sp.atk": 45,
+            "sp.def": 35,
+            "speed": 40,
+            "total": 198
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Kirlia": {
+        "name": "Kirlia",
+        "species": "Emotion Pokemon",
+        "id": "281",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "(0.8m)",
+        "weight": "(20.2 kg)",
+        "abilities": [
+            "Synchronize",
+            "Trace",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 35,
+            "defense": 35,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 50,
+            "total": 278
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Gardevoir": {
+        "name": "Gardevoir",
+        "species": "Embrace Pokemon",
+        "id": "282",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "(1.6m)",
+        "weight": "(48.4 kg)",
+        "abilities": [
+            "Synchronize",
+            "Trace",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 85,
+            "defense": 65,
+            "sp.atk": 165,
+            "sp.def": 135,
+            "speed": 100,
+            "total": 618
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Surskit": {
+        "name": "Surskit",
+        "species": "Pond Skater Pokemon",
+        "id": "283",
+        "type": [
+            "Bug",
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(1.7 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 32,
+            "sp.atk": 50,
+            "sp.def": 52,
+            "speed": 65,
+            "total": 269
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Masquerain": {
+        "name": "Masquerain",
+        "species": "Eyeball Pokemon",
+        "id": "284",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(0.8m)",
+        "weight": "(3.6 kg)",
+        "abilities": [
+            "Intimidate",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 60,
+            "defense": 62,
+            "sp.atk": 100,
+            "sp.def": 82,
+            "speed": 80,
+            "total": 454
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Shroomish": {
+        "name": "Shroomish",
+        "species": "Mushroom Pokemon",
+        "id": "285",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.5 kg)",
+        "abilities": [
+            "Effect Spore",
+            "Poison Heal",
+            "Quick Feet"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 40,
+            "defense": 60,
+            "sp.atk": 40,
+            "sp.def": 60,
+            "speed": 35,
+            "total": 295
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Breloom": {
+        "name": "Breloom",
+        "species": "Mushroom Pokemon",
+        "id": "286",
+        "type": [
+            "Grass",
+            "Fighting"
+        ],
+        "height": "(1.2m)",
+        "weight": "(39.2 kg)",
+        "abilities": [
+            "Effect Spore",
+            "Poison Heal",
+            "Technician"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 130,
+            "defense": 80,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 70,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Slakoth": {
+        "name": "Slakoth",
+        "species": "Slacker Pokemon",
+        "id": "287",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.8m)",
+        "weight": "(24 kg)",
+        "abilities": [
+            "Truant"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 30,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Vigoroth": {
+        "name": "Vigoroth",
+        "species": "Wild Monkey Pokemon",
+        "id": "288",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.4m)",
+        "weight": "(46.5 kg)",
+        "abilities": [
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 80,
+            "defense": 80,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 90,
+            "total": 440
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Slaking": {
+        "name": "Slaking",
+        "species": "Lazy Pokemon",
+        "id": "289",
+        "type": [
+            "Normal"
+        ],
+        "height": "(2m)",
+        "weight": "(130.5 kg)",
+        "abilities": [
+            "Truant"
+        ],
+        "stats": {
+            "hp": 150,
+            "attack": 160,
+            "defense": 100,
+            "sp.atk": 95,
+            "sp.def": 65,
+            "speed": 100,
+            "total": 670
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Nincada": {
+        "name": "Nincada",
+        "species": "Trainee Pokemon",
+        "id": "290",
+        "type": [
+            "Bug",
+            "Ground"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5.5 kg)",
+        "abilities": [
+            "Compoundeyes",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 31,
+            "attack": 45,
+            "defense": 90,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 40,
+            "total": 266
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Ninjask": {
+        "name": "Ninjask",
+        "species": "Ninja Pokemon",
+        "id": "291",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(0.8m)",
+        "weight": "(12 kg)",
+        "abilities": [
+            "Speed Boost",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 61,
+            "attack": 90,
+            "defense": 45,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 160,
+            "total": 456
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Shedinja": {
+        "name": "Shedinja",
+        "species": "Shed Pokemon",
+        "id": "292",
+        "type": [
+            "Bug",
+            "Ghost"
+        ],
+        "height": "(0.8m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Wonder Guard"
+        ],
+        "stats": {
+            "hp": 1,
+            "attack": 90,
+            "defense": 45,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 40,
+            "total": 236
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Whismur": {
+        "name": "Whismur",
+        "species": "Whisper Pokemon",
+        "id": "293",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(16.3 kg)",
+        "abilities": [
+            "Soundproof",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 64,
+            "attack": 51,
+            "defense": 23,
+            "sp.atk": 51,
+            "sp.def": 23,
+            "speed": 28,
+            "total": 240
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Loudred": {
+        "name": "Loudred",
+        "species": "Big Voice Pokemon",
+        "id": "294",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1m)",
+        "weight": "(40.5 kg)",
+        "abilities": [
+            "Soundproof",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 84,
+            "attack": 71,
+            "defense": 43,
+            "sp.atk": 71,
+            "sp.def": 43,
+            "speed": 48,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Exploud": {
+        "name": "Exploud",
+        "species": "Loud Noise Pokemon",
+        "id": "295",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.5m)",
+        "weight": "(84 kg)",
+        "abilities": [
+            "Soundproof",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 104,
+            "attack": 91,
+            "defense": 63,
+            "sp.atk": 91,
+            "sp.def": 73,
+            "speed": 68,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Makuhita": {
+        "name": "Makuhita",
+        "species": "Guts Pokemon",
+        "id": "296",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1m)",
+        "weight": "(86.4 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Guts",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 60,
+            "defense": 30,
+            "sp.atk": 20,
+            "sp.def": 30,
+            "speed": 25,
+            "total": 237
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Hariyama": {
+        "name": "Hariyama",
+        "species": "Arm Thrust Pokemon",
+        "id": "297",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(2.3m)",
+        "weight": "(253.8 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Guts",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 144,
+            "attack": 120,
+            "defense": 60,
+            "sp.atk": 40,
+            "sp.def": 60,
+            "speed": 50,
+            "total": 474
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Azurill": {
+        "name": "Azurill",
+        "species": "Polka Dot Pokemon",
+        "id": "298",
+        "type": [
+            "Normal",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Huge Power",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 20,
+            "defense": 40,
+            "sp.atk": 20,
+            "sp.def": 40,
+            "speed": 20,
+            "total": 190
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Nosepass": {
+        "name": "Nosepass",
+        "species": "Compass Pokemon",
+        "id": "299",
+        "type": [
+            "Rock"
+        ],
+        "height": "(1m)",
+        "weight": "(97 kg)",
+        "abilities": [
+            "Sturdy",
+            "Magnet Pull",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 45,
+            "defense": 135,
+            "sp.atk": 45,
+            "sp.def": 90,
+            "speed": 30,
+            "total": 375
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Skitty": {
+        "name": "Skitty",
+        "species": "Kitten Pokemon",
+        "id": "300",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Normalize",
+            "Wonder Skin "
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 45,
+            "defense": 45,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 50,
+            "total": 260
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Delcatty": {
+        "name": "Delcatty",
+        "species": "Prim Pokemon",
+        "id": "301",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.1m)",
+        "weight": "(32.6 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Normalize",
+            "Wonder Skin "
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 65,
+            "defense": 65,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 90,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Sableye": {
+        "name": "Sableye",
+        "species": "Darkness Pokemon",
+        "id": "302",
+        "type": [
+            "Dark",
+            "Ghost"
+        ],
+        "height": "(0.5m)",
+        "weight": "(11 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Stall",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 85,
+            "defense": 125,
+            "sp.atk": 85,
+            "sp.def": 115,
+            "speed": 20,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Mawile": {
+        "name": "Mawile",
+        "species": "Deceiver Pokemon",
+        "id": "303",
+        "type": [
+            "Steel",
+            "Fairy"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11.5 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Intimidate",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 105,
+            "defense": 125,
+            "sp.atk": 55,
+            "sp.def": 95,
+            "speed": 50,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Aron": {
+        "name": "Aron",
+        "species": "Iron Armor Pokemon",
+        "id": "304",
+        "type": [
+            "Steel",
+            "Rock"
+        ],
+        "height": "(0.4m)",
+        "weight": "(60 kg)",
+        "abilities": [
+            "Sturdy",
+            "Rock Head",
+            "Heavy Metal"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 70,
+            "defense": 100,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 30,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Lairon": {
+        "name": "Lairon",
+        "species": "Iron Armor Pokemon",
+        "id": "305",
+        "type": [
+            "Steel",
+            "Rock"
+        ],
+        "height": "(0.9m)",
+        "weight": "(120 kg)",
+        "abilities": [
+            "Sturdy",
+            "Rock Head",
+            "Heavy Metal"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 90,
+            "defense": 140,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 40,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Aggron": {
+        "name": "Aggron",
+        "species": "Iron Armor Pokemon",
+        "id": "306",
+        "type": [
+            "Steel",
+            "Rock"
+        ],
+        "height": "(2.1m)",
+        "weight": "(360 kg)",
+        "abilities": [
+            "Sturdy",
+            "Rock Head",
+            "Heavy Metal"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 140,
+            "defense": 230,
+            "sp.atk": 60,
+            "sp.def": 80,
+            "speed": 50,
+            "total": 630
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Meditite": {
+        "name": "Meditite",
+        "species": "Meditate Pokemon",
+        "id": "307",
+        "type": [
+            "Fighting",
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11.2 kg)",
+        "abilities": [
+            "Pure Power",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 40,
+            "defense": 55,
+            "sp.atk": 40,
+            "sp.def": 55,
+            "speed": 60,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Medicham": {
+        "name": "Medicham",
+        "species": "Meditate Pokemon",
+        "id": "308",
+        "type": [
+            "Fighting",
+            "Psychic"
+        ],
+        "height": "(1.3m)",
+        "weight": "(31.5 kg)",
+        "abilities": [
+            "Pure Power",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 100,
+            "defense": 85,
+            "sp.atk": 80,
+            "sp.def": 85,
+            "speed": 100,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Electrike": {
+        "name": "Electrike",
+        "species": "Lightning Pokemon",
+        "id": "309",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.6m)",
+        "weight": "(15.2 kg)",
+        "abilities": [
+            "Static",
+            "Lightningrod",
+            "Minus"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 40,
+            "sp.atk": 65,
+            "sp.def": 40,
+            "speed": 65,
+            "total": 295
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Manectric": {
+        "name": "Manectric",
+        "species": "Discharge Pokemon",
+        "id": "310",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.5m)",
+        "weight": "(40.2 kg)",
+        "abilities": [
+            "Static",
+            "Lightningrod",
+            "Minus"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 75,
+            "defense": 80,
+            "sp.atk": 135,
+            "sp.def": 80,
+            "speed": 135,
+            "total": 575
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Plusle": {
+        "name": "Plusle",
+        "species": "Cheering Pokemon",
+        "id": "311",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.2 kg)",
+        "abilities": [
+            "Plus",
+            "Lightningrod"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 50,
+            "defense": 40,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 95,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Minun": {
+        "name": "Minun",
+        "species": "Cheering Pokemon",
+        "id": "312",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.2 kg)",
+        "abilities": [
+            "Minus",
+            "Volt Absorb"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 40,
+            "defense": 50,
+            "sp.atk": 75,
+            "sp.def": 85,
+            "speed": 95,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Volbeat": {
+        "name": "Volbeat",
+        "species": "Firefly Pokemon",
+        "id": "313",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.7m)",
+        "weight": "(17.7 kg)",
+        "abilities": [
+            "Illuminate",
+            "Swarm",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 73,
+            "defense": 75,
+            "sp.atk": 47,
+            "sp.def": 85,
+            "speed": 85,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Illumise": {
+        "name": "Illumise",
+        "species": "Firefly Pokemon",
+        "id": "314",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.6m)",
+        "weight": "(17.7 kg)",
+        "abilities": [
+            "Oblivious",
+            "Tinted Lens",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 47,
+            "defense": 75,
+            "sp.atk": 73,
+            "sp.def": 85,
+            "speed": 85,
+            "total": 430
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Roselia": {
+        "name": "Roselia",
+        "species": "Thorn Pokemon",
+        "id": "315",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Poison Point",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 60,
+            "defense": 45,
+            "sp.atk": 100,
+            "sp.def": 80,
+            "speed": 65,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Gulpin": {
+        "name": "Gulpin",
+        "species": "Stomach Pokemon",
+        "id": "316",
+        "type": [
+            "Poison"
+        ],
+        "height": "(0.4m)",
+        "weight": "(10.3 kg)",
+        "abilities": [
+            "Liquid Ooze",
+            "Sticky Hold",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 43,
+            "defense": 53,
+            "sp.atk": 43,
+            "sp.def": 53,
+            "speed": 40,
+            "total": 302
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Swalot": {
+        "name": "Swalot",
+        "species": "Poison Bag Pokemon",
+        "id": "317",
+        "type": [
+            "Poison"
+        ],
+        "height": "(1.7m)",
+        "weight": "(80 kg)",
+        "abilities": [
+            "Liquid Ooze",
+            "Sticky Hold",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 73,
+            "defense": 83,
+            "sp.atk": 73,
+            "sp.def": 83,
+            "speed": 55,
+            "total": 467
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Carvanha": {
+        "name": "Carvanha",
+        "species": "Savage Pokemon",
+        "id": "318",
+        "type": [
+            "Water",
+            "Dark"
+        ],
+        "height": "(0.8m)",
+        "weight": "(20.8 kg)",
+        "abilities": [
+            "Rough Skin",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 90,
+            "defense": 20,
+            "sp.atk": 65,
+            "sp.def": 20,
+            "speed": 65,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Sharpedo": {
+        "name": "Sharpedo",
+        "species": "Brutal Pokemon",
+        "id": "319",
+        "type": [
+            "Water",
+            "Dark"
+        ],
+        "height": "(1.8m)",
+        "weight": "(88.8 kg)",
+        "abilities": [
+            "Rough Skin",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 140,
+            "defense": 70,
+            "sp.atk": 110,
+            "sp.def": 65,
+            "speed": 105,
+            "total": 560
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Wailmer": {
+        "name": "Wailmer",
+        "species": "Ball Whale Pokemon",
+        "id": "320",
+        "type": [
+            "Water"
+        ],
+        "height": "(2m)",
+        "weight": "(130 kg)",
+        "abilities": [
+            "Water Veil",
+            "Oblivious",
+            "Pressure"
+        ],
+        "stats": {
+            "hp": 130,
+            "attack": 70,
+            "defense": 35,
+            "sp.atk": 70,
+            "sp.def": 35,
+            "speed": 60,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Wailord": {
+        "name": "Wailord",
+        "species": "Float Whale Pokemon",
+        "id": "321",
+        "type": [
+            "Water"
+        ],
+        "height": "(14.5m)",
+        "weight": "(398 kg)",
+        "abilities": [
+            "Water Veil",
+            "Oblivious",
+            "Pressure"
+        ],
+        "stats": {
+            "hp": 170,
+            "attack": 90,
+            "defense": 45,
+            "sp.atk": 90,
+            "sp.def": 45,
+            "speed": 60,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Numel": {
+        "name": "Numel",
+        "species": "Numb Pokemon",
+        "id": "322",
+        "type": [
+            "Fire",
+            "Ground"
+        ],
+        "height": "(0.7m)",
+        "weight": "(24 kg)",
+        "abilities": [
+            "Oblivious",
+            "Simple",
+            "Own Tempo"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 40,
+            "sp.atk": 65,
+            "sp.def": 45,
+            "speed": 35,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Camerupt": {
+        "name": "Camerupt",
+        "species": "Eruption Pokemon",
+        "id": "323",
+        "type": [
+            "Fire",
+            "Ground"
+        ],
+        "height": "(1.9m)",
+        "weight": "(220 kg)",
+        "abilities": [
+            "Magma Armor",
+            "Solid Rock",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 120,
+            "defense": 100,
+            "sp.atk": 145,
+            "sp.def": 105,
+            "speed": 20,
+            "total": 560
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Torkoal": {
+        "name": "Torkoal",
+        "species": "Coal Pokemon",
+        "id": "324",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.5m)",
+        "weight": "(80.4 kg)",
+        "abilities": [
+            "White Smoke",
+            "Drought",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 85,
+            "defense": 140,
+            "sp.atk": 85,
+            "sp.def": 70,
+            "speed": 20,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Spoink": {
+        "name": "Spoink",
+        "species": "Bounce Pokemon",
+        "id": "325",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.7m)",
+        "weight": "(30.6 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Own Tempo",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 25,
+            "defense": 35,
+            "sp.atk": 70,
+            "sp.def": 80,
+            "speed": 60,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Grumpig": {
+        "name": "Grumpig",
+        "species": "Manipulate Pokemon",
+        "id": "326",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.9m)",
+        "weight": "(71.5 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Own Tempo",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 45,
+            "defense": 65,
+            "sp.atk": 90,
+            "sp.def": 110,
+            "speed": 80,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Spinda": {
+        "name": "Spinda",
+        "species": "Spot Panda Pokemon",
+        "id": "327",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.1m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Tangled Feet",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 60,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Trapinch": {
+        "name": "Trapinch",
+        "species": "Ant Pit Pokemon",
+        "id": "328",
+        "type": [
+            "Ground"
+        ],
+        "height": "(0.7m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Arena Trap",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 100,
+            "defense": 45,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 10,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Vibrava": {
+        "name": "Vibrava",
+        "species": "Vibration Pokemon",
+        "id": "329",
+        "type": [
+            "Ground",
+            "Dragon"
+        ],
+        "height": "(1.1m)",
+        "weight": "(15.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 70,
+            "defense": 50,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 70,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Flygon": {
+        "name": "Flygon",
+        "species": "Mystic Pokemon",
+        "id": "330",
+        "type": [
+            "Ground",
+            "Dragon"
+        ],
+        "height": "(2m)",
+        "weight": "(82 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 100,
+            "defense": 80,
+            "sp.atk": 80,
+            "sp.def": 80,
+            "speed": 100,
+            "total": 520
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Cacnea": {
+        "name": "Cacnea",
+        "species": "Cactus Pokemon",
+        "id": "331",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(51.3 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 85,
+            "defense": 40,
+            "sp.atk": 85,
+            "sp.def": 40,
+            "speed": 35,
+            "total": 335
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Cacturne": {
+        "name": "Cacturne",
+        "species": "Scarecrow Pokemon",
+        "id": "332",
+        "type": [
+            "Grass",
+            "Dark"
+        ],
+        "height": "(1.3m)",
+        "weight": "(77.4 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 115,
+            "defense": 60,
+            "sp.atk": 115,
+            "sp.def": 60,
+            "speed": 55,
+            "total": 475
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Swablu": {
+        "name": "Swablu",
+        "species": "Cotton Bird Pokemon",
+        "id": "333",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.4m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Cloud Nine"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 40,
+            "defense": 60,
+            "sp.atk": 40,
+            "sp.def": 75,
+            "speed": 50,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Altaria": {
+        "name": "Altaria",
+        "species": "Humming Pokemon",
+        "id": "334",
+        "type": [
+            "Dragon",
+            "Flying"
+        ],
+        "height": "(1.1m)",
+        "weight": "(20.6 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Cloud Nine"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 110,
+            "defense": 110,
+            "sp.atk": 110,
+            "sp.def": 105,
+            "speed": 80,
+            "total": 590
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Zangoose": {
+        "name": "Zangoose",
+        "species": "Cat Ferret Pokemon",
+        "id": "335",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.3m)",
+        "weight": "(40.3 kg)",
+        "abilities": [
+            "Immunity",
+            "Toxic Boost"
+        ],
+        "stats": {
+            "hp": 73,
+            "attack": 115,
+            "defense": 60,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 90,
+            "total": 458
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Seviper": {
+        "name": "Seviper",
+        "species": "Fang Snake Pokemon",
+        "id": "336",
+        "type": [
+            "Poison"
+        ],
+        "height": "(2.7m)",
+        "weight": "(52.5 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 73,
+            "attack": 100,
+            "defense": 60,
+            "sp.atk": 100,
+            "sp.def": 60,
+            "speed": 65,
+            "total": 458
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Lunatone": {
+        "name": "Lunatone",
+        "species": "Meteorite Pokemon",
+        "id": "337",
+        "type": [
+            "Rock",
+            "Psychic"
+        ],
+        "height": "(1m)",
+        "weight": "(168 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 55,
+            "defense": 65,
+            "sp.atk": 95,
+            "sp.def": 85,
+            "speed": 70,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Solrock": {
+        "name": "Solrock",
+        "species": "Meteorite Pokemon",
+        "id": "338",
+        "type": [
+            "Rock",
+            "Psychic"
+        ],
+        "height": "(1.2m)",
+        "weight": "(154 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 95,
+            "defense": 85,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 70,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Barboach": {
+        "name": "Barboach",
+        "species": "Whiskers Pokemon",
+        "id": "339",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.4m)",
+        "weight": "(1.9 kg)",
+        "abilities": [
+            "Oblivious",
+            "Anticipation",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 48,
+            "defense": 43,
+            "sp.atk": 46,
+            "sp.def": 41,
+            "speed": 60,
+            "total": 288
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Whiscash": {
+        "name": "Whiscash",
+        "species": "Whiskers Pokemon",
+        "id": "340",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.9m)",
+        "weight": "(23.6 kg)",
+        "abilities": [
+            "Oblivious",
+            "Anticipation",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 78,
+            "defense": 73,
+            "sp.atk": 76,
+            "sp.def": 71,
+            "speed": 60,
+            "total": 468
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Corphish": {
+        "name": "Corphish",
+        "species": "Ruffian Pokemon",
+        "id": "341",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11.5 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Shell Armor",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 43,
+            "attack": 80,
+            "defense": 65,
+            "sp.atk": 50,
+            "sp.def": 35,
+            "speed": 35,
+            "total": 308
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Crawdaunt": {
+        "name": "Crawdaunt",
+        "species": "Rogue Pokemon",
+        "id": "342",
+        "type": [
+            "Water",
+            "Dark"
+        ],
+        "height": "(1.1m)",
+        "weight": "(32.8 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Shell Armor",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 63,
+            "attack": 120,
+            "defense": 85,
+            "sp.atk": 90,
+            "sp.def": 55,
+            "speed": 55,
+            "total": 468
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Baltoy": {
+        "name": "Baltoy",
+        "species": "Clay Doll Pokemon",
+        "id": "343",
+        "type": [
+            "Ground",
+            "Psychic"
+        ],
+        "height": "(0.5m)",
+        "weight": "(21.5 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 40,
+            "defense": 55,
+            "sp.atk": 40,
+            "sp.def": 70,
+            "speed": 55,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Claydol": {
+        "name": "Claydol",
+        "species": "Clay Doll Pokemon",
+        "id": "344",
+        "type": [
+            "Ground",
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(108 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 70,
+            "defense": 105,
+            "sp.atk": 70,
+            "sp.def": 120,
+            "speed": 75,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Lileep": {
+        "name": "Lileep",
+        "species": "Sea Lily Pokemon",
+        "id": "345",
+        "type": [
+            "Rock",
+            "Grass"
+        ],
+        "height": "(1m)",
+        "weight": "(23.8 kg)",
+        "abilities": [
+            "Suction Cups",
+            "Storm Drain"
+        ],
+        "stats": {
+            "hp": 66,
+            "attack": 41,
+            "defense": 77,
+            "sp.atk": 61,
+            "sp.def": 87,
+            "speed": 23,
+            "total": 355
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Cradily": {
+        "name": "Cradily",
+        "species": "Barnacle Pokemon",
+        "id": "346",
+        "type": [
+            "Rock",
+            "Grass"
+        ],
+        "height": "(1.5m)",
+        "weight": "(60.4 kg)",
+        "abilities": [
+            "Suction Cups",
+            "Storm Drain"
+        ],
+        "stats": {
+            "hp": 86,
+            "attack": 81,
+            "defense": 97,
+            "sp.atk": 81,
+            "sp.def": 107,
+            "speed": 43,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Anorith": {
+        "name": "Anorith",
+        "species": "Old Shrimp Pokemon",
+        "id": "347",
+        "type": [
+            "Rock",
+            "Bug"
+        ],
+        "height": "(0.7m)",
+        "weight": "(12.5 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 95,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 75,
+            "total": 355
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Armaldo": {
+        "name": "Armaldo",
+        "species": "Plate Pokemon",
+        "id": "348",
+        "type": [
+            "Rock",
+            "Bug"
+        ],
+        "height": "(1.5m)",
+        "weight": "(68.2 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 125,
+            "defense": 100,
+            "sp.atk": 70,
+            "sp.def": 80,
+            "speed": 45,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Feebas": {
+        "name": "Feebas",
+        "species": "Fish Pokemon",
+        "id": "349",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(7.4 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Oblivious",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 15,
+            "defense": 20,
+            "sp.atk": 10,
+            "sp.def": 55,
+            "speed": 80,
+            "total": 200
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Milotic": {
+        "name": "Milotic",
+        "species": "Tender Pokemon",
+        "id": "350",
+        "type": [
+            "Water"
+        ],
+        "height": "(6.2m)",
+        "weight": "(162 kg)",
+        "abilities": [
+            "Marvel Scale",
+            "Competitive",
+            "Cute Charm"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 60,
+            "defense": 79,
+            "sp.atk": 100,
+            "sp.def": 125,
+            "speed": 81,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Castform": {
+        "name": "Castform",
+        "species": "Weather Pokemon",
+        "id": "351",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.8 kg)",
+        "abilities": [
+            "Forecast"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 70,
+            "defense": 70,
+            "sp.atk": 70,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Kecleon": {
+        "name": "Kecleon",
+        "species": "Color Swap Pokemon",
+        "id": "352",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1m)",
+        "weight": "(22 kg)",
+        "abilities": [
+            "Color Change",
+            "Protean"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 90,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 120,
+            "speed": 40,
+            "total": 440
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Shuppet": {
+        "name": "Shuppet",
+        "species": "Puppet Pokemon",
+        "id": "353",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(0.6m)",
+        "weight": "(2.3 kg)",
+        "abilities": [
+            "Insomnia",
+            "Frisk",
+            "Cursed Body"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 75,
+            "defense": 35,
+            "sp.atk": 63,
+            "sp.def": 33,
+            "speed": 45,
+            "total": 295
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Banette": {
+        "name": "Banette",
+        "species": "Marionette Pokemon",
+        "id": "354",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(1.1m)",
+        "weight": "(12.5 kg)",
+        "abilities": [
+            "Insomnia",
+            "Frisk",
+            "Cursed Body"
+        ],
+        "stats": {
+            "hp": 64,
+            "attack": 165,
+            "defense": 75,
+            "sp.atk": 93,
+            "sp.def": 83,
+            "speed": 75,
+            "total": 555
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Duskull": {
+        "name": "Duskull",
+        "species": "Requiem Pokemon",
+        "id": "355",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(0.8m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Levitate",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 40,
+            "defense": 90,
+            "sp.atk": 30,
+            "sp.def": 90,
+            "speed": 25,
+            "total": 295
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Dusclops": {
+        "name": "Dusclops",
+        "species": "Beckon Pokemon",
+        "id": "356",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(1.6m)",
+        "weight": "(30.6 kg)",
+        "abilities": [
+            "Pressure",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 70,
+            "defense": 130,
+            "sp.atk": 60,
+            "sp.def": 130,
+            "speed": 25,
+            "total": 455
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Tropius": {
+        "name": "Tropius",
+        "species": "Fruit Pokemon",
+        "id": "357",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(2m)",
+        "weight": "(100 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Solar Power",
+            "Harvest"
+        ],
+        "stats": {
+            "hp": 99,
+            "attack": 68,
+            "defense": 83,
+            "sp.atk": 72,
+            "sp.def": 87,
+            "speed": 51,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Chimecho": {
+        "name": "Chimecho",
+        "species": "Wind Chime Pokemon",
+        "id": "358",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 50,
+            "defense": 80,
+            "sp.atk": 95,
+            "sp.def": 90,
+            "speed": 65,
+            "total": 455
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Absol": {
+        "name": "Absol",
+        "species": "Disaster Pokemon",
+        "id": "359",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1.2m)",
+        "weight": "(47 kg)",
+        "abilities": [
+            "Pressure",
+            "Super Luck",
+            "Justified"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 150,
+            "defense": 60,
+            "sp.atk": 115,
+            "sp.def": 60,
+            "speed": 115,
+            "total": 565
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Wynaut": {
+        "name": "Wynaut",
+        "species": "Bright Pokemon",
+        "id": "360",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(14 kg)",
+        "abilities": [
+            "Shadow Tag",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 23,
+            "defense": 48,
+            "sp.atk": 23,
+            "sp.def": 48,
+            "speed": 23,
+            "total": 260
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Snorunt": {
+        "name": "Snorunt",
+        "species": "Snow Hat Pokemon",
+        "id": "361",
+        "type": [
+            "Ice"
+        ],
+        "height": "(0.7m)",
+        "weight": "(16.8 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Ice Body",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 50,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 50,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Glalie": {
+        "name": "Glalie",
+        "species": "Face Pokemon",
+        "id": "362",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1.5m)",
+        "weight": "(256.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Ice Body",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 120,
+            "defense": 80,
+            "sp.atk": 120,
+            "sp.def": 80,
+            "speed": 100,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Spheal": {
+        "name": "Spheal",
+        "species": "Clap Pokemon",
+        "id": "363",
+        "type": [
+            "Ice",
+            "Water"
+        ],
+        "height": "(0.8m)",
+        "weight": "(39.5 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Ice Body",
+            "Oblivious"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 40,
+            "defense": 50,
+            "sp.atk": 55,
+            "sp.def": 50,
+            "speed": 25,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Sealeo": {
+        "name": "Sealeo",
+        "species": "Ball Roll Pokemon",
+        "id": "364",
+        "type": [
+            "Ice",
+            "Water"
+        ],
+        "height": "(1.1m)",
+        "weight": "(87.6 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Ice Body",
+            "Oblivious"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 60,
+            "defense": 70,
+            "sp.atk": 75,
+            "sp.def": 70,
+            "speed": 45,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Walrein": {
+        "name": "Walrein",
+        "species": "Ice Break Pokemon",
+        "id": "365",
+        "type": [
+            "Ice",
+            "Water"
+        ],
+        "height": "(1.4m)",
+        "weight": "(150.6 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Ice Body",
+            "Oblivious"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 80,
+            "defense": 90,
+            "sp.atk": 95,
+            "sp.def": 90,
+            "speed": 65,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Clamperl": {
+        "name": "Clamperl",
+        "species": "Bivalve Pokemon",
+        "id": "366",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(52.5 kg)",
+        "abilities": [
+            "Shell Armor",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 64,
+            "defense": 85,
+            "sp.atk": 74,
+            "sp.def": 55,
+            "speed": 32,
+            "total": 345
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Huntail": {
+        "name": "Huntail",
+        "species": "Deep Sea Pokemon",
+        "id": "367",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.7m)",
+        "weight": "(27 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 104,
+            "defense": 105,
+            "sp.atk": 94,
+            "sp.def": 75,
+            "speed": 52,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Gorebyss": {
+        "name": "Gorebyss",
+        "species": "South Sea Pokemon",
+        "id": "368",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.8m)",
+        "weight": "(22.6 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 84,
+            "defense": 105,
+            "sp.atk": 114,
+            "sp.def": 75,
+            "speed": 52,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Relicanth": {
+        "name": "Relicanth",
+        "species": "Longevity Pokemon",
+        "id": "369",
+        "type": [
+            "Water",
+            "Rock"
+        ],
+        "height": "(1m)",
+        "weight": "(23.4 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Rock Head",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 90,
+            "defense": 130,
+            "sp.atk": 45,
+            "sp.def": 65,
+            "speed": 55,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Luvdisc": {
+        "name": "Luvdisc",
+        "species": "Rendezvous Pokemon",
+        "id": "370",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8.7 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 43,
+            "attack": 30,
+            "defense": 55,
+            "sp.atk": 40,
+            "sp.def": 65,
+            "speed": 97,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Bagon": {
+        "name": "Bagon",
+        "species": "Rock Head Pokemon",
+        "id": "371",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(0.6m)",
+        "weight": "(42.1 kg)",
+        "abilities": [
+            "Rock Head",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 75,
+            "defense": 60,
+            "sp.atk": 40,
+            "sp.def": 30,
+            "speed": 50,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Shelgon": {
+        "name": "Shelgon",
+        "species": "Endurance Pokemon",
+        "id": "372",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(1.1m)",
+        "weight": "(110.5 kg)",
+        "abilities": [
+            "Rock Head",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 95,
+            "defense": 100,
+            "sp.atk": 60,
+            "sp.def": 50,
+            "speed": 50,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Salamence": {
+        "name": "Salamence",
+        "species": "Dragon Pokemon",
+        "id": "373",
+        "type": [
+            "Dragon",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(102.6 kg)",
+        "abilities": [
+            "Intimidate",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 145,
+            "defense": 130,
+            "sp.atk": 120,
+            "sp.def": 90,
+            "speed": 120,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Beldum": {
+        "name": "Beldum",
+        "species": "Iron Ball Pokemon",
+        "id": "374",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(95.2 kg)",
+        "abilities": [
+            "Clear Body",
+            "Light Metal"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 80,
+            "sp.atk": 35,
+            "sp.def": 60,
+            "speed": 30,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Metang": {
+        "name": "Metang",
+        "species": "Iron Claw Pokemon",
+        "id": "375",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(1.2m)",
+        "weight": "(202.5 kg)",
+        "abilities": [
+            "Clear Body",
+            "Light Metal"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 75,
+            "defense": 100,
+            "sp.atk": 55,
+            "sp.def": 80,
+            "speed": 50,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Metagross": {
+        "name": "Metagross",
+        "species": "Iron Leg Pokemon",
+        "id": "376",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(1.6m)",
+        "weight": "(550 kg)",
+        "abilities": [
+            "Clear Body",
+            "Light Metal"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 145,
+            "defense": 150,
+            "sp.atk": 105,
+            "sp.def": 110,
+            "speed": 110,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Regirock": {
+        "name": "Regirock",
+        "species": "Rock Peak Pokemon",
+        "id": "377",
+        "type": [
+            "Rock"
+        ],
+        "height": "(1.7m)",
+        "weight": "(230 kg)",
+        "abilities": [
+            "Clear Body",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 100,
+            "defense": 200,
+            "sp.atk": 50,
+            "sp.def": 100,
+            "speed": 50,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Regice": {
+        "name": "Regice",
+        "species": "Iceberg Pokemon",
+        "id": "378",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1.8m)",
+        "weight": "(175 kg)",
+        "abilities": [
+            "Clear Body",
+            "Ice Body"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 50,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 200,
+            "speed": 50,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Registeel": {
+        "name": "Registeel",
+        "species": "Iron Pokemon",
+        "id": "379",
+        "type": [
+            "Steel"
+        ],
+        "height": "(1.9m)",
+        "weight": "(205 kg)",
+        "abilities": [
+            "Clear Body",
+            "Light Metal"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 75,
+            "defense": 150,
+            "sp.atk": 75,
+            "sp.def": 150,
+            "speed": 50,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Latias": {
+        "name": "Latias",
+        "species": "Eon Pokemon",
+        "id": "380",
+        "type": [
+            "Dragon",
+            "Psychic"
+        ],
+        "height": "(1.4m)",
+        "weight": "(40 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 100,
+            "defense": 120,
+            "sp.atk": 140,
+            "sp.def": 150,
+            "speed": 110,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Latios": {
+        "name": "Latios",
+        "species": "Eon Pokemon",
+        "id": "381",
+        "type": [
+            "Dragon",
+            "Psychic"
+        ],
+        "height": "(2m)",
+        "weight": "(60 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 130,
+            "defense": 100,
+            "sp.atk": 160,
+            "sp.def": 120,
+            "speed": 110,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Kyogre": {
+        "name": "Kyogre",
+        "species": "Sea Basin Pokemon",
+        "id": "382",
+        "type": [
+            "Water"
+        ],
+        "height": "(4.5m)",
+        "weight": "(352 kg)",
+        "abilities": [
+            "Drizzle"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 150,
+            "defense": 90,
+            "sp.atk": 180,
+            "sp.def": 160,
+            "speed": 90,
+            "total": 770
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Groudon": {
+        "name": "Groudon",
+        "species": "Continent Pokemon",
+        "id": "383",
+        "type": [
+            "Ground"
+        ],
+        "height": "(3.5m)",
+        "weight": "(950 kg)",
+        "abilities": [
+            "Drought"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 180,
+            "defense": 160,
+            "sp.atk": 150,
+            "sp.def": 90,
+            "speed": 90,
+            "total": 770
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Rayquaza": {
+        "name": "Rayquaza",
+        "species": "Sky High Pokemon",
+        "id": "384",
+        "type": [
+            "Dragon",
+            "Flying"
+        ],
+        "height": "(7m)",
+        "weight": "(206.5 kg)",
+        "abilities": [
+            "Air Lock"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 180,
+            "defense": 100,
+            "sp.atk": 180,
+            "sp.def": 100,
+            "speed": 115,
+            "total": 780
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Jirachi": {
+        "name": "Jirachi",
+        "species": "Wish Pokemon",
+        "id": "385",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.1 kg)",
+        "abilities": [
+            "Serene Grace"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Deoxys": {
+        "name": "Deoxys",
+        "species": "DNA Pokemon",
+        "id": "386",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1.7m)",
+        "weight": "(60.8 kg)",
+        "abilities": [
+            "Pressure"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 95,
+            "defense": 90,
+            "sp.atk": 95,
+            "sp.def": 90,
+            "speed": 180,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 3
+    },
+    "Turtwig": {
+        "name": "Turtwig",
+        "species": "Tiny Leaf Pokemon",
+        "id": "387",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(10.2 kg)",
+        "abilities": [
+            "Overgrow",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 68,
+            "defense": 64,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 31,
+            "total": 318
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Grotle": {
+        "name": "Grotle",
+        "species": "Grove Pokemon",
+        "id": "388",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.1m)",
+        "weight": "(97 kg)",
+        "abilities": [
+            "Overgrow",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 89,
+            "defense": 85,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 36,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Torterra": {
+        "name": "Torterra",
+        "species": "Continent Pokemon",
+        "id": "389",
+        "type": [
+            "Grass",
+            "Ground"
+        ],
+        "height": "(2.2m)",
+        "weight": "(310 kg)",
+        "abilities": [
+            "Overgrow",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 109,
+            "defense": 105,
+            "sp.atk": 75,
+            "sp.def": 85,
+            "speed": 56,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Chimchar": {
+        "name": "Chimchar",
+        "species": "Chimp Pokemon",
+        "id": "390",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.5m)",
+        "weight": "(6.2 kg)",
+        "abilities": [
+            "Blaze",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 58,
+            "defense": 44,
+            "sp.atk": 58,
+            "sp.def": 44,
+            "speed": 61,
+            "total": 309
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Monferno": {
+        "name": "Monferno",
+        "species": "Playful Pokemon",
+        "id": "391",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(0.9m)",
+        "weight": "(22 kg)",
+        "abilities": [
+            "Blaze",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 64,
+            "attack": 78,
+            "defense": 52,
+            "sp.atk": 78,
+            "sp.def": 52,
+            "speed": 81,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Infernape": {
+        "name": "Infernape",
+        "species": "Flame Pokemon",
+        "id": "392",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(1.2m)",
+        "weight": "(55 kg)",
+        "abilities": [
+            "Blaze",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 76,
+            "attack": 104,
+            "defense": 71,
+            "sp.atk": 104,
+            "sp.def": 71,
+            "speed": 108,
+            "total": 534
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Piplup": {
+        "name": "Piplup",
+        "species": "Penguin Pokemon",
+        "id": "393",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.2 kg)",
+        "abilities": [
+            "Torrent",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 53,
+            "attack": 51,
+            "defense": 53,
+            "sp.atk": 61,
+            "sp.def": 56,
+            "speed": 40,
+            "total": 314
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Prinplup": {
+        "name": "Prinplup",
+        "species": "Penguin Pokemon",
+        "id": "394",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.8m)",
+        "weight": "(23 kg)",
+        "abilities": [
+            "Torrent",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 64,
+            "attack": 66,
+            "defense": 68,
+            "sp.atk": 81,
+            "sp.def": 76,
+            "speed": 50,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Empoleon": {
+        "name": "Empoleon",
+        "species": "Emperor Pokemon",
+        "id": "395",
+        "type": [
+            "Water",
+            "Steel"
+        ],
+        "height": "(1.7m)",
+        "weight": "(84.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 84,
+            "attack": 86,
+            "defense": 88,
+            "sp.atk": 111,
+            "sp.def": 101,
+            "speed": 60,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Starly": {
+        "name": "Starly",
+        "species": "Starling Pokemon",
+        "id": "396",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 30,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 60,
+            "total": 245
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Staravia": {
+        "name": "Staravia",
+        "species": "Starling Pokemon",
+        "id": "397",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(15.5 kg)",
+        "abilities": [
+            "Intimidate",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 75,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 80,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Staraptor": {
+        "name": "Staraptor",
+        "species": "Predator Pokemon",
+        "id": "398",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(24.9 kg)",
+        "abilities": [
+            "Intimidate",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 120,
+            "defense": 70,
+            "sp.atk": 50,
+            "sp.def": 60,
+            "speed": 100,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bidoof": {
+        "name": "Bidoof",
+        "species": "Plump Mouse Pokemon",
+        "id": "399",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(20 kg)",
+        "abilities": [
+            "Simple",
+            "Unaware",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 45,
+            "defense": 40,
+            "sp.atk": 35,
+            "sp.def": 40,
+            "speed": 31,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bibarel": {
+        "name": "Bibarel",
+        "species": "Beaver Pokemon",
+        "id": "400",
+        "type": [
+            "Normal",
+            "Water"
+        ],
+        "height": "(1m)",
+        "weight": "(31.5 kg)",
+        "abilities": [
+            "Simple",
+            "Unaware",
+            "Moody"
+        ],
+        "stats": {
+            "hp": 79,
+            "attack": 85,
+            "defense": 60,
+            "sp.atk": 55,
+            "sp.def": 60,
+            "speed": 71,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Kricketot": {
+        "name": "Kricketot",
+        "species": "Cricket Pokemon",
+        "id": "401",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.2 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 37,
+            "attack": 25,
+            "defense": 41,
+            "sp.atk": 25,
+            "sp.def": 41,
+            "speed": 25,
+            "total": 194
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Kricketune": {
+        "name": "Kricketune",
+        "species": "Cricket Pokemon",
+        "id": "402",
+        "type": [
+            "Bug"
+        ],
+        "height": "(1m)",
+        "weight": "(25.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Technician"
+        ],
+        "stats": {
+            "hp": 77,
+            "attack": 85,
+            "defense": 51,
+            "sp.atk": 55,
+            "sp.def": 51,
+            "speed": 65,
+            "total": 384
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Shinx": {
+        "name": "Shinx",
+        "species": "Flash Pokemon",
+        "id": "403",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9.5 kg)",
+        "abilities": [
+            "Rivalry",
+            "Intimidate",
+            "Guts"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 65,
+            "defense": 34,
+            "sp.atk": 40,
+            "sp.def": 34,
+            "speed": 45,
+            "total": 263
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Luxio": {
+        "name": "Luxio",
+        "species": "Spark Pokemon",
+        "id": "404",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.9m)",
+        "weight": "(30.5 kg)",
+        "abilities": [
+            "Rivalry",
+            "Intimidate",
+            "Guts"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 49,
+            "sp.atk": 60,
+            "sp.def": 49,
+            "speed": 60,
+            "total": 363
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Luxray": {
+        "name": "Luxray",
+        "species": "Gleam Eyes Pokemon",
+        "id": "405",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.4m)",
+        "weight": "(42 kg)",
+        "abilities": [
+            "Rivalry",
+            "Intimidate",
+            "Guts"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 120,
+            "defense": 79,
+            "sp.atk": 95,
+            "sp.def": 79,
+            "speed": 70,
+            "total": 523
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Budew": {
+        "name": "Budew",
+        "species": "Bud Pokemon",
+        "id": "406",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "(0.2m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Poison Point",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 35,
+            "sp.atk": 50,
+            "sp.def": 70,
+            "speed": 55,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Roserade": {
+        "name": "Roserade",
+        "species": "Bouquet Pokemon",
+        "id": "407",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "(0.9m)",
+        "weight": "(14.5 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Poison Point",
+            "Technician"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 70,
+            "defense": 65,
+            "sp.atk": 125,
+            "sp.def": 105,
+            "speed": 90,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Cranidos": {
+        "name": "Cranidos",
+        "species": "Head Butt Pokemon",
+        "id": "408",
+        "type": [
+            "Rock"
+        ],
+        "height": "(0.9m)",
+        "weight": "(31.5 kg)",
+        "abilities": [
+            "Mold Breaker",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 67,
+            "attack": 125,
+            "defense": 40,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 58,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Rampardos": {
+        "name": "Rampardos",
+        "species": "Head Butt Pokemon",
+        "id": "409",
+        "type": [
+            "Rock"
+        ],
+        "height": "(1.6m)",
+        "weight": "(102.5 kg)",
+        "abilities": [
+            "Mold Breaker",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 97,
+            "attack": 165,
+            "defense": 60,
+            "sp.atk": 65,
+            "sp.def": 50,
+            "speed": 58,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Shieldon": {
+        "name": "Shieldon",
+        "species": "Shield Pokemon",
+        "id": "410",
+        "type": [
+            "Rock",
+            "Steel"
+        ],
+        "height": "(0.5m)",
+        "weight": "(57 kg)",
+        "abilities": [
+            "Sturdy",
+            "Soundproof"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 42,
+            "defense": 118,
+            "sp.atk": 42,
+            "sp.def": 88,
+            "speed": 30,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bastiodon": {
+        "name": "Bastiodon",
+        "species": "Shield Pokemon",
+        "id": "411",
+        "type": [
+            "Rock",
+            "Steel"
+        ],
+        "height": "(1.3m)",
+        "weight": "(149.5 kg)",
+        "abilities": [
+            "Sturdy",
+            "Soundproof"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 52,
+            "defense": 168,
+            "sp.atk": 47,
+            "sp.def": 138,
+            "speed": 30,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Burmy": {
+        "name": "Burmy",
+        "species": "Bagworm Pokemon",
+        "id": "412",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.2m)",
+        "weight": "(3.4 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 29,
+            "defense": 45,
+            "sp.atk": 29,
+            "sp.def": 45,
+            "speed": 36,
+            "total": 224
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Wormadam": {
+        "name": "Wormadam",
+        "species": "Bagworm Pokemon",
+        "id": "413",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(6.5 kg)",
+        "abilities": [
+            "Anticipation",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 69,
+            "defense": 95,
+            "sp.atk": 69,
+            "sp.def": 95,
+            "speed": 36,
+            "total": 424
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mothim": {
+        "name": "Mothim",
+        "species": "Moth Pokemon",
+        "id": "414",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(0.9m)",
+        "weight": "(23.3 kg)",
+        "abilities": [
+            "Swarm",
+            "Tinted Lens"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 94,
+            "defense": 50,
+            "sp.atk": 94,
+            "sp.def": 50,
+            "speed": 66,
+            "total": 424
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Combee": {
+        "name": "Combee",
+        "species": "Tiny Bee Pokemon",
+        "id": "415",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(5.5 kg)",
+        "abilities": [
+            "Honey Gather",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 30,
+            "defense": 42,
+            "sp.atk": 30,
+            "sp.def": 42,
+            "speed": 70,
+            "total": 244
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Vespiquen": {
+        "name": "Vespiquen",
+        "species": "Beehive Pokemon",
+        "id": "416",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(38.5 kg)",
+        "abilities": [
+            "Pressure",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 80,
+            "defense": 102,
+            "sp.atk": 80,
+            "sp.def": 102,
+            "speed": 40,
+            "total": 474
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Pachirisu": {
+        "name": "Pachirisu",
+        "species": "EleSquirrel Pokemon",
+        "id": "417",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.4m)",
+        "weight": "(3.9 kg)",
+        "abilities": [
+            "Run Away",
+            "Pickup",
+            "Volt Absorb"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 45,
+            "defense": 70,
+            "sp.atk": 45,
+            "sp.def": 90,
+            "speed": 95,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Buizel": {
+        "name": "Buizel",
+        "species": "Sea Weasel Pokemon",
+        "id": "418",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.7m)",
+        "weight": "(29.5 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 65,
+            "defense": 35,
+            "sp.atk": 60,
+            "sp.def": 30,
+            "speed": 85,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Floatzel": {
+        "name": "Floatzel",
+        "species": "Sea Weasel Pokemon",
+        "id": "419",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.1m)",
+        "weight": "(33.5 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 105,
+            "defense": 55,
+            "sp.atk": 85,
+            "sp.def": 50,
+            "speed": 115,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Cherubi": {
+        "name": "Cherubi",
+        "species": "Cherry Pokemon",
+        "id": "420",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(3.3 kg)",
+        "abilities": [
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 35,
+            "defense": 45,
+            "sp.atk": 62,
+            "sp.def": 53,
+            "speed": 35,
+            "total": 275
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Cherrim": {
+        "name": "Cherrim",
+        "species": "Blossom Pokemon",
+        "id": "421",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9.3 kg)",
+        "abilities": [
+            "Flower Gift"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 60,
+            "defense": 70,
+            "sp.atk": 87,
+            "sp.def": 78,
+            "speed": 85,
+            "total": 450
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Shellos": {
+        "name": "Shellos",
+        "species": "Sea Slug Pokemon",
+        "id": "422",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.3m)",
+        "weight": "(6.3 kg)",
+        "abilities": [
+            "Sticky Hold",
+            "Storm Drain",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 76,
+            "attack": 48,
+            "defense": 48,
+            "sp.atk": 57,
+            "sp.def": 62,
+            "speed": 34,
+            "total": 325
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Gastrodon": {
+        "name": "Gastrodon",
+        "species": "Sea Slug Pokemon",
+        "id": "423",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.9m)",
+        "weight": "(29.9 kg)",
+        "abilities": [
+            "Sticky Hold",
+            "Storm Drain",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 111,
+            "attack": 83,
+            "defense": 68,
+            "sp.atk": 92,
+            "sp.def": 82,
+            "speed": 39,
+            "total": 475
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Ambipom": {
+        "name": "Ambipom",
+        "species": "Long Tail Pokemon",
+        "id": "424",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(20.3 kg)",
+        "abilities": [
+            "Technician",
+            "Pickup",
+            "Skill Link"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 100,
+            "defense": 66,
+            "sp.atk": 60,
+            "sp.def": 66,
+            "speed": 115,
+            "total": 482
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Drifloon": {
+        "name": "Drifloon",
+        "species": "Balloon Pokemon",
+        "id": "425",
+        "type": [
+            "Ghost",
+            "Flying"
+        ],
+        "height": "(0.4m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Aftermath",
+            "Unburden",
+            "Flare Boost"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 50,
+            "defense": 34,
+            "sp.atk": 60,
+            "sp.def": 44,
+            "speed": 70,
+            "total": 348
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Drifblim": {
+        "name": "Drifblim",
+        "species": "Blimp Pokemon",
+        "id": "426",
+        "type": [
+            "Ghost",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Aftermath",
+            "Unburden",
+            "Flare Boost"
+        ],
+        "stats": {
+            "hp": 150,
+            "attack": 80,
+            "defense": 44,
+            "sp.atk": 90,
+            "sp.def": 54,
+            "speed": 80,
+            "total": 498
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Buneary": {
+        "name": "Buneary",
+        "species": "Rabbit Pokemon",
+        "id": "427",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.5 kg)",
+        "abilities": [
+            "Run Away",
+            "Klutz",
+            "Limber"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 66,
+            "defense": 44,
+            "sp.atk": 44,
+            "sp.def": 56,
+            "speed": 85,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Lopunny": {
+        "name": "Lopunny",
+        "species": "Rabbit Pokemon",
+        "id": "428",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(33.3 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Klutz",
+            "Limber"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 136,
+            "defense": 94,
+            "sp.atk": 54,
+            "sp.def": 96,
+            "speed": 135,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mismagius": {
+        "name": "Mismagius",
+        "species": "Magical Pokemon",
+        "id": "429",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(0.9m)",
+        "weight": "(4.4 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 105,
+            "sp.def": 105,
+            "speed": 105,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Honchkrow": {
+        "name": "Honchkrow",
+        "species": "Big Boss Pokemon",
+        "id": "430",
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "height": "(0.9m)",
+        "weight": "(27.3 kg)",
+        "abilities": [
+            "Insomnia",
+            "Super Luck",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 125,
+            "defense": 52,
+            "sp.atk": 105,
+            "sp.def": 52,
+            "speed": 71,
+            "total": 505
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Glameow": {
+        "name": "Glameow",
+        "species": "Catty Pokemon",
+        "id": "431",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(3.9 kg)",
+        "abilities": [
+            "Limber",
+            "Own Tempo",
+            "Keen Eye"
+        ],
+        "stats": {
+            "hp": 49,
+            "attack": 55,
+            "defense": 42,
+            "sp.atk": 42,
+            "sp.def": 37,
+            "speed": 85,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Purugly": {
+        "name": "Purugly",
+        "species": "Tiger Cat Pokemon",
+        "id": "432",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1m)",
+        "weight": "(43.8 kg)",
+        "abilities": [
+            "Thick Fat",
+            "Own Tempo",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 71,
+            "attack": 82,
+            "defense": 64,
+            "sp.atk": 64,
+            "sp.def": 59,
+            "speed": 112,
+            "total": 452
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Chingling": {
+        "name": "Chingling",
+        "species": "Bell Pokemon",
+        "id": "433",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.6 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 30,
+            "defense": 50,
+            "sp.atk": 65,
+            "sp.def": 50,
+            "speed": 45,
+            "total": 285
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Stunky": {
+        "name": "Stunky",
+        "species": "Skunk Pokemon",
+        "id": "434",
+        "type": [
+            "Poison",
+            "Dark"
+        ],
+        "height": "(0.4m)",
+        "weight": "(19.2 kg)",
+        "abilities": [
+            "Stench",
+            "Aftermath",
+            "Keen Eye"
+        ],
+        "stats": {
+            "hp": 63,
+            "attack": 63,
+            "defense": 47,
+            "sp.atk": 41,
+            "sp.def": 41,
+            "speed": 74,
+            "total": 329
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Skuntank": {
+        "name": "Skuntank",
+        "species": "Skunk Pokemon",
+        "id": "435",
+        "type": [
+            "Poison",
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(38 kg)",
+        "abilities": [
+            "Stench",
+            "Aftermath",
+            "Keen Eye"
+        ],
+        "stats": {
+            "hp": 103,
+            "attack": 93,
+            "defense": 67,
+            "sp.atk": 71,
+            "sp.def": 61,
+            "speed": 84,
+            "total": 479
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bronzor": {
+        "name": "Bronzor",
+        "species": "Bronze Pokemon",
+        "id": "436",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(0.5m)",
+        "weight": "(60.5 kg)",
+        "abilities": [
+            "Levitate",
+            "Heatproof",
+            "Heavy Metal"
+        ],
+        "stats": {
+            "hp": 57,
+            "attack": 24,
+            "defense": 86,
+            "sp.atk": 24,
+            "sp.def": 86,
+            "speed": 23,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bronzong": {
+        "name": "Bronzong",
+        "species": "Bronze Bell Pokemon",
+        "id": "437",
+        "type": [
+            "Steel",
+            "Psychic"
+        ],
+        "height": "(1.3m)",
+        "weight": "(187 kg)",
+        "abilities": [
+            "Levitate",
+            "Heatproof",
+            "Heavy Metal"
+        ],
+        "stats": {
+            "hp": 67,
+            "attack": 89,
+            "defense": 116,
+            "sp.atk": 79,
+            "sp.def": 116,
+            "speed": 33,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Bonsly": {
+        "name": "Bonsly",
+        "species": "Bonsai Pokemon",
+        "id": "438",
+        "type": [
+            "Rock"
+        ],
+        "height": "(0.5m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Sturdy",
+            "Rock Head",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 80,
+            "defense": 95,
+            "sp.atk": 10,
+            "sp.def": 45,
+            "speed": 10,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mime Jr.": {
+        "name": "Mime Jr.",
+        "species": "Mime Pokemon",
+        "id": "439",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "(0.6m)",
+        "weight": "(13 kg)",
+        "abilities": [
+            "Soundproof",
+            "Filter",
+            "Technician"
+        ],
+        "stats": {
+            "hp": 20,
+            "attack": 25,
+            "defense": 45,
+            "sp.atk": 70,
+            "sp.def": 90,
+            "speed": 60,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Happiny": {
+        "name": "Happiny",
+        "species": "Playhouse Pokemon",
+        "id": "440",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(24.4 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Serene Grace",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 5,
+            "defense": 5,
+            "sp.atk": 15,
+            "sp.def": 65,
+            "speed": 30,
+            "total": 220
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Chatot": {
+        "name": "Chatot",
+        "species": "Music Note Pokemon",
+        "id": "441",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(1.9 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Tangled Feet",
+            "Big Pecks"
+        ],
+        "stats": {
+            "hp": 76,
+            "attack": 65,
+            "defense": 45,
+            "sp.atk": 92,
+            "sp.def": 42,
+            "speed": 91,
+            "total": 411
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Spiritomb": {
+        "name": "Spiritomb",
+        "species": "Forbidden Pokemon",
+        "id": "442",
+        "type": [
+            "Ghost",
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(108 kg)",
+        "abilities": [
+            "Pressure",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 92,
+            "defense": 108,
+            "sp.atk": 92,
+            "sp.def": 108,
+            "speed": 35,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Gible": {
+        "name": "Gible",
+        "species": "Land Shark Pokemon",
+        "id": "443",
+        "type": [
+            "Dragon",
+            "Ground"
+        ],
+        "height": "(0.7m)",
+        "weight": "(20.5 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Rough Skin"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 70,
+            "defense": 45,
+            "sp.atk": 40,
+            "sp.def": 45,
+            "speed": 42,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Gabite": {
+        "name": "Gabite",
+        "species": "Cave Pokemon",
+        "id": "444",
+        "type": [
+            "Dragon",
+            "Ground"
+        ],
+        "height": "(1.4m)",
+        "weight": "(56 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Rough Skin"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 90,
+            "defense": 65,
+            "sp.atk": 50,
+            "sp.def": 55,
+            "speed": 82,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Garchomp": {
+        "name": "Garchomp",
+        "species": "Mach Pokemon",
+        "id": "445",
+        "type": [
+            "Dragon",
+            "Ground"
+        ],
+        "height": "(1.9m)",
+        "weight": "(95 kg)",
+        "abilities": [
+            "Sand Veil",
+            "Rough Skin"
+        ],
+        "stats": {
+            "hp": 108,
+            "attack": 170,
+            "defense": 115,
+            "sp.atk": 120,
+            "sp.def": 95,
+            "speed": 92,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Munchlax": {
+        "name": "Munchlax",
+        "species": "Big Eater Pokemon",
+        "id": "446",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(105 kg)",
+        "abilities": [
+            "Pickup",
+            "Thick Fat",
+            "Gluttony"
+        ],
+        "stats": {
+            "hp": 135,
+            "attack": 85,
+            "defense": 40,
+            "sp.atk": 40,
+            "sp.def": 85,
+            "speed": 5,
+            "total": 390
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Riolu": {
+        "name": "Riolu",
+        "species": "Emanation Pokemon",
+        "id": "447",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.7m)",
+        "weight": "(20.2 kg)",
+        "abilities": [
+            "Steadfast",
+            "Inner Focus",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 70,
+            "defense": 40,
+            "sp.atk": 35,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 285
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Lucario": {
+        "name": "Lucario",
+        "species": "Aura Pokemon",
+        "id": "448",
+        "type": [
+            "Fighting",
+            "Steel"
+        ],
+        "height": "(1.2m)",
+        "weight": "(54 kg)",
+        "abilities": [
+            "Steadfast",
+            "Inner Focus",
+            "Justified"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 145,
+            "defense": 88,
+            "sp.atk": 140,
+            "sp.def": 70,
+            "speed": 112,
+            "total": 625
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Hippopotas": {
+        "name": "Hippopotas",
+        "species": "Hippo Pokemon",
+        "id": "449",
+        "type": [
+            "Ground"
+        ],
+        "height": "(0.8m)",
+        "weight": "(49.5 kg)",
+        "abilities": [
+            "Sand Stream",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 72,
+            "defense": 78,
+            "sp.atk": 38,
+            "sp.def": 42,
+            "speed": 32,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Hippowdon": {
+        "name": "Hippowdon",
+        "species": "Heavyweight Pokemon",
+        "id": "450",
+        "type": [
+            "Ground"
+        ],
+        "height": "(2m)",
+        "weight": "(300 kg)",
+        "abilities": [
+            "Sand Stream",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 108,
+            "attack": 112,
+            "defense": 118,
+            "sp.atk": 68,
+            "sp.def": 72,
+            "speed": 47,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Skorupi": {
+        "name": "Skorupi",
+        "species": "Scorpion Pokemon",
+        "id": "451",
+        "type": [
+            "Poison",
+            "Bug"
+        ],
+        "height": "(0.8m)",
+        "weight": "(12 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Sniper",
+            "Keen Eye"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 50,
+            "defense": 90,
+            "sp.atk": 30,
+            "sp.def": 55,
+            "speed": 65,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Drapion": {
+        "name": "Drapion",
+        "species": "Ogre Scorp Pokemon",
+        "id": "452",
+        "type": [
+            "Poison",
+            "Dark"
+        ],
+        "height": "(1.3m)",
+        "weight": "(61.5 kg)",
+        "abilities": [
+            "Battle Armor",
+            "Sniper",
+            "Keen Eye"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 90,
+            "defense": 110,
+            "sp.atk": 60,
+            "sp.def": 75,
+            "speed": 95,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Croagunk": {
+        "name": "Croagunk",
+        "species": "Toxic Mouth Pokemon",
+        "id": "453",
+        "type": [
+            "Poison",
+            "Fighting"
+        ],
+        "height": "(0.7m)",
+        "weight": "(23 kg)",
+        "abilities": [
+            "Anticipation",
+            "Dry Skin",
+            "Poison Touch"
+        ],
+        "stats": {
+            "hp": 48,
+            "attack": 61,
+            "defense": 40,
+            "sp.atk": 61,
+            "sp.def": 40,
+            "speed": 50,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Toxicroak": {
+        "name": "Toxicroak",
+        "species": "Toxic Mouth Pokemon",
+        "id": "454",
+        "type": [
+            "Poison",
+            "Fighting"
+        ],
+        "height": "(1.3m)",
+        "weight": "(44.4 kg)",
+        "abilities": [
+            "Anticipation",
+            "Dry Skin",
+            "Poison Touch"
+        ],
+        "stats": {
+            "hp": 83,
+            "attack": 106,
+            "defense": 65,
+            "sp.atk": 86,
+            "sp.def": 65,
+            "speed": 85,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Carnivine": {
+        "name": "Carnivine",
+        "species": "Bug Catcher Pokemon",
+        "id": "455",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.4m)",
+        "weight": "(27 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 74,
+            "attack": 100,
+            "defense": 72,
+            "sp.atk": 90,
+            "sp.def": 72,
+            "speed": 46,
+            "total": 454
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Finneon": {
+        "name": "Finneon",
+        "species": "Wing Fish Pokemon",
+        "id": "456",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(7 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Storm Drain",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 49,
+            "attack": 49,
+            "defense": 56,
+            "sp.atk": 49,
+            "sp.def": 61,
+            "speed": 66,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Lumineon": {
+        "name": "Lumineon",
+        "species": "Neon Pokemon",
+        "id": "457",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.2m)",
+        "weight": "(24 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Storm Drain",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 69,
+            "attack": 69,
+            "defense": 76,
+            "sp.atk": 69,
+            "sp.def": 86,
+            "speed": 91,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mantyke": {
+        "name": "Mantyke",
+        "species": "Kite Pokemon",
+        "id": "458",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(1m)",
+        "weight": "(65 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Water Absorb",
+            "Water Veil"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 20,
+            "defense": 50,
+            "sp.atk": 60,
+            "sp.def": 120,
+            "speed": 50,
+            "total": 345
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Snover": {
+        "name": "Snover",
+        "species": "Frosted Tree Pokemon",
+        "id": "459",
+        "type": [
+            "Grass",
+            "Ice"
+        ],
+        "height": "(1m)",
+        "weight": "(50.5 kg)",
+        "abilities": [
+            "Snow Warning",
+            "Soundproof"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 62,
+            "defense": 50,
+            "sp.atk": 62,
+            "sp.def": 60,
+            "speed": 40,
+            "total": 334
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Abomasnow": {
+        "name": "Abomasnow",
+        "species": "Frosted Tree Pokemon",
+        "id": "460",
+        "type": [
+            "Grass",
+            "Ice"
+        ],
+        "height": "(2.2m)",
+        "weight": "(135.5 kg)",
+        "abilities": [
+            "Snow Warning",
+            "Soundproof"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 132,
+            "defense": 105,
+            "sp.atk": 132,
+            "sp.def": 105,
+            "speed": 30,
+            "total": 594
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Weavile": {
+        "name": "Weavile",
+        "species": "Sharp Claw Pokemon",
+        "id": "461",
+        "type": [
+            "Dark",
+            "Ice"
+        ],
+        "height": "(1.1m)",
+        "weight": "(34 kg)",
+        "abilities": [
+            "Pressure",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 120,
+            "defense": 65,
+            "sp.atk": 45,
+            "sp.def": 85,
+            "speed": 125,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Magnezone": {
+        "name": "Magnezone",
+        "species": "Magnet Area Pokemon",
+        "id": "462",
+        "type": [
+            "Electric",
+            "Steel"
+        ],
+        "height": "(1.2m)",
+        "weight": "(180 kg)",
+        "abilities": [
+            "Magnet Pull",
+            "Sturdy",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 70,
+            "defense": 115,
+            "sp.atk": 130,
+            "sp.def": 90,
+            "speed": 60,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Lickilicky": {
+        "name": "Lickilicky",
+        "species": "Licking Pokemon",
+        "id": "463",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.7m)",
+        "weight": "(140 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Oblivious",
+            "Cloud Nine"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 85,
+            "defense": 95,
+            "sp.atk": 80,
+            "sp.def": 95,
+            "speed": 50,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Rhyperior": {
+        "name": "Rhyperior",
+        "species": "Drill Pokemon",
+        "id": "464",
+        "type": [
+            "Ground",
+            "Rock"
+        ],
+        "height": "(2.4m)",
+        "weight": "(282.8 kg)",
+        "abilities": [
+            "Lightningrod",
+            "Solid Rock",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 115,
+            "attack": 140,
+            "defense": 130,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 40,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Tangrowth": {
+        "name": "Tangrowth",
+        "species": "Vine Pokemon",
+        "id": "465",
+        "type": [
+            "Grass"
+        ],
+        "height": "(2m)",
+        "weight": "(128.6 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Leaf Guard",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 125,
+            "sp.atk": 110,
+            "sp.def": 50,
+            "speed": 50,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Electivire": {
+        "name": "Electivire",
+        "species": "Thunderbolt Pokemon",
+        "id": "466",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.8m)",
+        "weight": "(138.6 kg)",
+        "abilities": [
+            "Motor Drive",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 123,
+            "defense": 67,
+            "sp.atk": 95,
+            "sp.def": 85,
+            "speed": 95,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Magmortar": {
+        "name": "Magmortar",
+        "species": "Blast Pokemon",
+        "id": "467",
+        "type": [
+            "Fire"
+        ],
+        "height": "(1.6m)",
+        "weight": "(68 kg)",
+        "abilities": [
+            "Flame Body",
+            "Vital Spirit"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 95,
+            "defense": 67,
+            "sp.atk": 125,
+            "sp.def": 95,
+            "speed": 83,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Togekiss": {
+        "name": "Togekiss",
+        "species": "Jubilee Pokemon",
+        "id": "468",
+        "type": [
+            "Fairy",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(38 kg)",
+        "abilities": [
+            "Hustle",
+            "Serene Grace",
+            "Super Luck"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 50,
+            "defense": 95,
+            "sp.atk": 120,
+            "sp.def": 115,
+            "speed": 80,
+            "total": 545
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Yanmega": {
+        "name": "Yanmega",
+        "species": "Ogre Darner Pokemon",
+        "id": "469",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1.9m)",
+        "weight": "(51.5 kg)",
+        "abilities": [
+            "Speed Boost",
+            "Tinted Lens",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 86,
+            "attack": 76,
+            "defense": 86,
+            "sp.atk": 116,
+            "sp.def": 56,
+            "speed": 95,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Leafeon": {
+        "name": "Leafeon",
+        "species": "Verdant Pokemon",
+        "id": "470",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1m)",
+        "weight": "(25.5 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 110,
+            "defense": 130,
+            "sp.atk": 60,
+            "sp.def": 65,
+            "speed": 95,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Glaceon": {
+        "name": "Glaceon",
+        "species": "Fresh Snow Pokemon",
+        "id": "471",
+        "type": [
+            "Ice"
+        ],
+        "height": "(0.8m)",
+        "weight": "(25.9 kg)",
+        "abilities": [
+            "Snow Cloak",
+            "Ice Body"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 60,
+            "defense": 110,
+            "sp.atk": 130,
+            "sp.def": 95,
+            "speed": 65,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Gliscor": {
+        "name": "Gliscor",
+        "species": "Fang Scorp Pokemon",
+        "id": "472",
+        "type": [
+            "Ground",
+            "Flying"
+        ],
+        "height": "(2m)",
+        "weight": "(42.5 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Sand Veil",
+            "Poison Heal"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 95,
+            "defense": 125,
+            "sp.atk": 45,
+            "sp.def": 75,
+            "speed": 95,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mamoswine": {
+        "name": "Mamoswine",
+        "species": "Twin Tusk Pokemon",
+        "id": "473",
+        "type": [
+            "Ice",
+            "Ground"
+        ],
+        "height": "(2.5m)",
+        "weight": "(291 kg)",
+        "abilities": [
+            "Oblivious",
+            "Snow Cloak",
+            "Thick Fat"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 130,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 60,
+            "speed": 80,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Porygon-Z": {
+        "name": "Porygon-Z",
+        "species": "Virtual Pokemon",
+        "id": "474",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.9m)",
+        "weight": "(34 kg)",
+        "abilities": [
+            "Adaptability",
+            "Download",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 80,
+            "defense": 70,
+            "sp.atk": 135,
+            "sp.def": 75,
+            "speed": 90,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Gallade": {
+        "name": "Gallade",
+        "species": "Blade Pokemon",
+        "id": "475",
+        "type": [
+            "Psychic",
+            "Fighting"
+        ],
+        "height": "(1.6m)",
+        "weight": "(52 kg)",
+        "abilities": [
+            "Steadfast",
+            "Justified"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 165,
+            "defense": 95,
+            "sp.atk": 65,
+            "sp.def": 115,
+            "speed": 110,
+            "total": 618
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Probopass": {
+        "name": "Probopass",
+        "species": "Compass Pokemon",
+        "id": "476",
+        "type": [
+            "Rock",
+            "Steel"
+        ],
+        "height": "(1.4m)",
+        "weight": "(340 kg)",
+        "abilities": [
+            "Sturdy",
+            "Magnet Pull",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 55,
+            "defense": 145,
+            "sp.atk": 75,
+            "sp.def": 150,
+            "speed": 40,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Dusknoir": {
+        "name": "Dusknoir",
+        "species": "Gripper Pokemon",
+        "id": "477",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(2.2m)",
+        "weight": "(106.6 kg)",
+        "abilities": [
+            "Pressure",
+            "Frisk"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 100,
+            "defense": 135,
+            "sp.atk": 65,
+            "sp.def": 135,
+            "speed": 45,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Froslass": {
+        "name": "Froslass",
+        "species": "Snow Land Pokemon",
+        "id": "478",
+        "type": [
+            "Ice",
+            "Ghost"
+        ],
+        "height": "(1.3m)",
+        "weight": "(26.6 kg)",
+        "abilities": [
+            "Snow Cloak",
+            "Cursed Body"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 80,
+            "defense": 70,
+            "sp.atk": 80,
+            "sp.def": 70,
+            "speed": 110,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Rotom": {
+        "name": "Rotom",
+        "species": "Plasma Pokemon",
+        "id": "479",
+        "type": [
+            "Electric",
+            "Ghost"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 65,
+            "defense": 107,
+            "sp.atk": 105,
+            "sp.def": 107,
+            "speed": 86,
+            "total": 520
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Uxie": {
+        "name": "Uxie",
+        "species": "Knowledge Pokemon",
+        "id": "480",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 75,
+            "defense": 130,
+            "sp.atk": 75,
+            "sp.def": 130,
+            "speed": 95,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Mesprit": {
+        "name": "Mesprit",
+        "species": "Emotion Pokemon",
+        "id": "481",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 105,
+            "defense": 105,
+            "sp.atk": 105,
+            "sp.def": 105,
+            "speed": 80,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Azelf": {
+        "name": "Azelf",
+        "species": "Willpower Pokemon",
+        "id": "482",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 125,
+            "defense": 70,
+            "sp.atk": 125,
+            "sp.def": 70,
+            "speed": 115,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Dialga": {
+        "name": "Dialga",
+        "species": "Temporal Pokemon",
+        "id": "483",
+        "type": [
+            "Steel",
+            "Dragon"
+        ],
+        "height": "(5.4m)",
+        "weight": "(683 kg)",
+        "abilities": [
+            "Pressure",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 120,
+            "defense": 120,
+            "sp.atk": 150,
+            "sp.def": 100,
+            "speed": 90,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Palkia": {
+        "name": "Palkia",
+        "species": "Spatial Pokemon",
+        "id": "484",
+        "type": [
+            "Water",
+            "Dragon"
+        ],
+        "height": "(4.2m)",
+        "weight": "(336 kg)",
+        "abilities": [
+            "Pressure",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 120,
+            "defense": 100,
+            "sp.atk": 150,
+            "sp.def": 120,
+            "speed": 100,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Heatran": {
+        "name": "Heatran",
+        "species": "Lava Dome Pokemon",
+        "id": "485",
+        "type": [
+            "Fire",
+            "Steel"
+        ],
+        "height": "(1.7m)",
+        "weight": "(430 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Flame Body"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 90,
+            "defense": 106,
+            "sp.atk": 130,
+            "sp.def": 106,
+            "speed": 77,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Regigigas": {
+        "name": "Regigigas",
+        "species": "Colossal Pokemon",
+        "id": "486",
+        "type": [
+            "Normal"
+        ],
+        "height": "(3.7m)",
+        "weight": "(420 kg)",
+        "abilities": [
+            "Slow Start"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 160,
+            "defense": 110,
+            "sp.atk": 80,
+            "sp.def": 110,
+            "speed": 100,
+            "total": 670
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Giratina": {
+        "name": "Giratina",
+        "species": "Renegade Pokemon",
+        "id": "487",
+        "type": [
+            "Ghost",
+            "Dragon"
+        ],
+        "height": "(4.5m)",
+        "weight": "(750 kg)",
+        "abilities": [
+            "Pressure",
+            "Telepathy",
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 150,
+            "attack": 120,
+            "defense": 100,
+            "sp.atk": 120,
+            "sp.def": 100,
+            "speed": 90,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Cresselia": {
+        "name": "Cresselia",
+        "species": "Lunar Pokemon",
+        "id": "488",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(85.6 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 120,
+            "attack": 70,
+            "defense": 120,
+            "sp.atk": 75,
+            "sp.def": 130,
+            "speed": 85,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Phione": {
+        "name": "Phione",
+        "species": "Sea Drifter Pokemon",
+        "id": "489",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(3.1 kg)",
+        "abilities": [
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 80,
+            "defense": 80,
+            "sp.atk": 80,
+            "sp.def": 80,
+            "speed": 80,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Manaphy": {
+        "name": "Manaphy",
+        "species": "Seafaring Pokemon",
+        "id": "490",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.4 kg)",
+        "abilities": [
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Darkrai": {
+        "name": "Darkrai",
+        "species": "Pitch-Black Pokemon",
+        "id": "491",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1.5m)",
+        "weight": "(50.5 kg)",
+        "abilities": [
+            "Bad Dreams"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 90,
+            "defense": 90,
+            "sp.atk": 135,
+            "sp.def": 90,
+            "speed": 125,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Shaymin": {
+        "name": "Shaymin",
+        "species": "Gratitude Pokemon",
+        "id": "492",
+        "type": [
+            "Grass",
+            "Grass"
+        ],
+        "height": "(0.2m)",
+        "weight": "(2.1 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Serene Grace"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 103,
+            "defense": 75,
+            "sp.atk": 120,
+            "sp.def": 75,
+            "speed": 127,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Arceus": {
+        "name": "Arceus",
+        "species": "Alpha Pokemon",
+        "id": "493",
+        "type": [
+            "Normal"
+        ],
+        "height": "(3.2m)",
+        "weight": "(320 kg)",
+        "abilities": [
+            "Multitype"
+        ],
+        "stats": {
+            "hp": 120,
+            "attack": 120,
+            "defense": 120,
+            "sp.atk": 120,
+            "sp.def": 120,
+            "speed": 120,
+            "total": 720
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 4
+    },
+    "Victini": {
+        "name": "Victini",
+        "species": "Victory Pokemon",
+        "id": "494",
+        "type": [
+            "Psychic",
+            "Fire"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4 kg)",
+        "abilities": [
+            "Victory Star"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 100,
+            "defense": 100,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 100,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Snivy": {
+        "name": "Snivy",
+        "species": "Grass Snake Pokemon",
+        "id": "495",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8.1 kg)",
+        "abilities": [
+            "Overgrow",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 45,
+            "defense": 55,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 63,
+            "total": 308
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Servine": {
+        "name": "Servine",
+        "species": "Grass Snake Pokemon",
+        "id": "496",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.8m)",
+        "weight": "(16 kg)",
+        "abilities": [
+            "Overgrow",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 75,
+            "sp.atk": 60,
+            "sp.def": 75,
+            "speed": 83,
+            "total": 413
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Serperior": {
+        "name": "Serperior",
+        "species": "Regal Pokemon",
+        "id": "497",
+        "type": [
+            "Grass"
+        ],
+        "height": "(3.3m)",
+        "weight": "(63 kg)",
+        "abilities": [
+            "Overgrow",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 75,
+            "defense": 95,
+            "sp.atk": 75,
+            "sp.def": 95,
+            "speed": 113,
+            "total": 528
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tepig": {
+        "name": "Tepig",
+        "species": "Fire Pig Pokemon",
+        "id": "498",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9.9 kg)",
+        "abilities": [
+            "Blaze",
+            "Thick Fat"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 63,
+            "defense": 45,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 45,
+            "total": 308
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Pignite": {
+        "name": "Pignite",
+        "species": "Fire Pig Pokemon",
+        "id": "499",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(1m)",
+        "weight": "(55.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Thick Fat"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 93,
+            "defense": 55,
+            "sp.atk": 70,
+            "sp.def": 55,
+            "speed": 55,
+            "total": 418
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Emboar": {
+        "name": "Emboar",
+        "species": "Mega Fire Pig Pokemon",
+        "id": "500",
+        "type": [
+            "Fire",
+            "Fighting"
+        ],
+        "height": "(1.6m)",
+        "weight": "(150 kg)",
+        "abilities": [
+            "Blaze",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 123,
+            "defense": 65,
+            "sp.atk": 100,
+            "sp.def": 65,
+            "speed": 65,
+            "total": 528
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Oshawott": {
+        "name": "Oshawott",
+        "species": "Sea Otter Pokemon",
+        "id": "501",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5.9 kg)",
+        "abilities": [
+            "Torrent",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 55,
+            "defense": 45,
+            "sp.atk": 63,
+            "sp.def": 45,
+            "speed": 45,
+            "total": 308
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Dewott": {
+        "name": "Dewott",
+        "species": "Discipline Pokemon",
+        "id": "502",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.8m)",
+        "weight": "(24.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 75,
+            "defense": 60,
+            "sp.atk": 83,
+            "sp.def": 60,
+            "speed": 60,
+            "total": 413
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Samurott": {
+        "name": "Samurott",
+        "species": "Formidable Pokemon",
+        "id": "503",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.5m)",
+        "weight": "(94.6 kg)",
+        "abilities": [
+            "Torrent",
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 100,
+            "defense": 85,
+            "sp.atk": 108,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 528
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Patrat": {
+        "name": "Patrat",
+        "species": "Scout Pokemon",
+        "id": "504",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(11.6 kg)",
+        "abilities": [
+            "Run Away",
+            "Keen Eye",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 55,
+            "defense": 39,
+            "sp.atk": 35,
+            "sp.def": 39,
+            "speed": 42,
+            "total": 255
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Watchog": {
+        "name": "Watchog",
+        "species": "Lookout Pokemon",
+        "id": "505",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.1m)",
+        "weight": "(27 kg)",
+        "abilities": [
+            "Illuminate",
+            "Keen Eye",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 69,
+            "sp.atk": 60,
+            "sp.def": 69,
+            "speed": 77,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Lillipup": {
+        "name": "Lillipup",
+        "species": "Puppy Pokemon",
+        "id": "506",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.1 kg)",
+        "abilities": [
+            "Vital Spirit",
+            "Pickup",
+            "Run Away"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 60,
+            "defense": 45,
+            "sp.atk": 25,
+            "sp.def": 45,
+            "speed": 55,
+            "total": 275
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Herdier": {
+        "name": "Herdier",
+        "species": "Loyal Dog Pokemon",
+        "id": "507",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.9m)",
+        "weight": "(14.7 kg)",
+        "abilities": [
+            "Intimidate",
+            "Sand Rush",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 80,
+            "defense": 65,
+            "sp.atk": 35,
+            "sp.def": 65,
+            "speed": 60,
+            "total": 370
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Stoutland": {
+        "name": "Stoutland",
+        "species": "Big-Hearted Pokemon",
+        "id": "508",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(61 kg)",
+        "abilities": [
+            "Intimidate",
+            "Sand Rush",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 110,
+            "defense": 90,
+            "sp.atk": 45,
+            "sp.def": 90,
+            "speed": 80,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Purrloin": {
+        "name": "Purrloin",
+        "species": "Devious Pokemon",
+        "id": "509",
+        "type": [
+            "Dark"
+        ],
+        "height": "(0.4m)",
+        "weight": "(10.1 kg)",
+        "abilities": [
+            "Limber",
+            "Unburden",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 41,
+            "attack": 50,
+            "defense": 37,
+            "sp.atk": 50,
+            "sp.def": 37,
+            "speed": 66,
+            "total": 281
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Liepard": {
+        "name": "Liepard",
+        "species": "Cruel Pokemon",
+        "id": "510",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1.1m)",
+        "weight": "(37.5 kg)",
+        "abilities": [
+            "Limber",
+            "Unburden",
+            "Prankster"
+        ],
+        "stats": {
+            "hp": 64,
+            "attack": 88,
+            "defense": 50,
+            "sp.atk": 88,
+            "sp.def": 50,
+            "speed": 106,
+            "total": 446
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Pansage": {
+        "name": "Pansage",
+        "species": "Grass Monkey Pokemon",
+        "id": "511",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.6m)",
+        "weight": "(10.5 kg)",
+        "abilities": [
+            "Gluttony",
+            "Overgrow"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 53,
+            "defense": 48,
+            "sp.atk": 53,
+            "sp.def": 48,
+            "speed": 64,
+            "total": 316
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Simisage": {
+        "name": "Simisage",
+        "species": "Thorn Monkey Pokemon",
+        "id": "512",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.1m)",
+        "weight": "(30.5 kg)",
+        "abilities": [
+            "Gluttony",
+            "Overgrow"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 98,
+            "defense": 63,
+            "sp.atk": 98,
+            "sp.def": 63,
+            "speed": 101,
+            "total": 498
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Pansear": {
+        "name": "Pansear",
+        "species": "High Temp Pokemon",
+        "id": "513",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11 kg)",
+        "abilities": [
+            "Gluttony",
+            "Blaze"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 53,
+            "defense": 48,
+            "sp.atk": 53,
+            "sp.def": 48,
+            "speed": 64,
+            "total": 316
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Simisear": {
+        "name": "Simisear",
+        "species": "Ember Pokemon",
+        "id": "514",
+        "type": [
+            "Fire"
+        ],
+        "height": "(1m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Gluttony",
+            "Blaze"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 98,
+            "defense": 63,
+            "sp.atk": 98,
+            "sp.def": 63,
+            "speed": 101,
+            "total": 498
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Panpour": {
+        "name": "Panpour",
+        "species": "Spray Pokemon",
+        "id": "515",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(13.5 kg)",
+        "abilities": [
+            "Gluttony",
+            "Torrent"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 53,
+            "defense": 48,
+            "sp.atk": 53,
+            "sp.def": 48,
+            "speed": 64,
+            "total": 316
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Simipour": {
+        "name": "Simipour",
+        "species": "Geyser Pokemon",
+        "id": "516",
+        "type": [
+            "Water"
+        ],
+        "height": "(1m)",
+        "weight": "(29 kg)",
+        "abilities": [
+            "Gluttony",
+            "Torrent"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 98,
+            "defense": 63,
+            "sp.atk": 98,
+            "sp.def": 63,
+            "speed": 101,
+            "total": 498
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Munna": {
+        "name": "Munna",
+        "species": "Dream Eater Pokemon",
+        "id": "517",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(23.3 kg)",
+        "abilities": [
+            "Forewarn",
+            "Synchronize",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 76,
+            "attack": 25,
+            "defense": 45,
+            "sp.atk": 67,
+            "sp.def": 55,
+            "speed": 24,
+            "total": 292
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Musharna": {
+        "name": "Musharna",
+        "species": "Drowsing Pokemon",
+        "id": "518",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1.1m)",
+        "weight": "(60.5 kg)",
+        "abilities": [
+            "Forewarn",
+            "Synchronize",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 116,
+            "attack": 55,
+            "defense": 85,
+            "sp.atk": 107,
+            "sp.def": 95,
+            "speed": 29,
+            "total": 487
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Pidove": {
+        "name": "Pidove",
+        "species": "Tiny Pigeon Pokemon",
+        "id": "519",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.1 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Super Luck",
+            "Rivalry"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 55,
+            "defense": 50,
+            "sp.atk": 36,
+            "sp.def": 30,
+            "speed": 43,
+            "total": 264
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tranquill": {
+        "name": "Tranquill",
+        "species": "Wild Pigeon Pokemon",
+        "id": "520",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Super Luck",
+            "Rivalry"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 77,
+            "defense": 62,
+            "sp.atk": 50,
+            "sp.def": 42,
+            "speed": 65,
+            "total": 358
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Unfezant": {
+        "name": "Unfezant",
+        "species": "Proud Pokemon",
+        "id": "521",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(29 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Super Luck",
+            "Rivalry"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 115,
+            "defense": 80,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 93,
+            "total": 488
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Blitzle": {
+        "name": "Blitzle",
+        "species": "Electrified Pokemon",
+        "id": "522",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.8m)",
+        "weight": "(29.8 kg)",
+        "abilities": [
+            "Lightningrod",
+            "Motor Drive",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 60,
+            "defense": 32,
+            "sp.atk": 50,
+            "sp.def": 32,
+            "speed": 76,
+            "total": 295
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Zebstrika": {
+        "name": "Zebstrika",
+        "species": "Thunderbolt Pokemon",
+        "id": "523",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.6m)",
+        "weight": "(79.5 kg)",
+        "abilities": [
+            "Lightningrod",
+            "Motor Drive",
+            "Sap Sipper"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 100,
+            "defense": 63,
+            "sp.atk": 80,
+            "sp.def": 63,
+            "speed": 116,
+            "total": 497
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Roggenrola": {
+        "name": "Roggenrola",
+        "species": "Mantle Pokemon",
+        "id": "524",
+        "type": [
+            "Rock"
+        ],
+        "height": "(0.4m)",
+        "weight": "(18 kg)",
+        "abilities": [
+            "Sturdy",
+            "Weak Armor",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 75,
+            "defense": 85,
+            "sp.atk": 25,
+            "sp.def": 25,
+            "speed": 15,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Boldore": {
+        "name": "Boldore",
+        "species": "Ore Pokemon",
+        "id": "525",
+        "type": [
+            "Rock"
+        ],
+        "height": "(0.9m)",
+        "weight": "(102 kg)",
+        "abilities": [
+            "Sturdy",
+            "Weak Armor",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 105,
+            "defense": 105,
+            "sp.atk": 50,
+            "sp.def": 40,
+            "speed": 20,
+            "total": 390
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Gigalith": {
+        "name": "Gigalith",
+        "species": "Compressed Pokemon",
+        "id": "526",
+        "type": [
+            "Rock"
+        ],
+        "height": "(1.7m)",
+        "weight": "(260 kg)",
+        "abilities": [
+            "Sturdy",
+            "Sand Stream",
+            "Sand Force"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 135,
+            "defense": 130,
+            "sp.atk": 60,
+            "sp.def": 80,
+            "speed": 25,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Woobat": {
+        "name": "Woobat",
+        "species": "Bat Pokemon",
+        "id": "527",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(0.4m)",
+        "weight": "(2.1 kg)",
+        "abilities": [
+            "Unaware",
+            "Klutz",
+            "Simple"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 45,
+            "defense": 43,
+            "sp.atk": 55,
+            "sp.def": 43,
+            "speed": 72,
+            "total": 323
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Swoobat": {
+        "name": "Swoobat",
+        "species": "Courting Pokemon",
+        "id": "528",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(0.9m)",
+        "weight": "(10.5 kg)",
+        "abilities": [
+            "Unaware",
+            "Klutz",
+            "Simple"
+        ],
+        "stats": {
+            "hp": 67,
+            "attack": 57,
+            "defense": 55,
+            "sp.atk": 77,
+            "sp.def": 55,
+            "speed": 114,
+            "total": 425
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Drilbur": {
+        "name": "Drilbur",
+        "species": "Mole Pokemon",
+        "id": "529",
+        "type": [
+            "Ground"
+        ],
+        "height": "(0.3m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Sand Rush",
+            "Sand Force",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 85,
+            "defense": 40,
+            "sp.atk": 30,
+            "sp.def": 45,
+            "speed": 68,
+            "total": 328
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Excadrill": {
+        "name": "Excadrill",
+        "species": "Subterrene Pokemon",
+        "id": "530",
+        "type": [
+            "Ground",
+            "Steel"
+        ],
+        "height": "(0.7m)",
+        "weight": "(40.4 kg)",
+        "abilities": [
+            "Sand Rush",
+            "Sand Force",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 135,
+            "defense": 60,
+            "sp.atk": 50,
+            "sp.def": 65,
+            "speed": 88,
+            "total": 508
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Audino": {
+        "name": "Audino",
+        "species": "Hearing Pokemon",
+        "id": "531",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.1m)",
+        "weight": "(31 kg)",
+        "abilities": [
+            "Healer",
+            "Regenerator",
+            "Klutz"
+        ],
+        "stats": {
+            "hp": 103,
+            "attack": 60,
+            "defense": 126,
+            "sp.atk": 80,
+            "sp.def": 126,
+            "speed": 50,
+            "total": 545
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Timburr": {
+        "name": "Timburr",
+        "species": "Muscular Pokemon",
+        "id": "532",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.6m)",
+        "weight": "(12.5 kg)",
+        "abilities": [
+            "Guts",
+            "Sheer Force",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 80,
+            "defense": 55,
+            "sp.atk": 25,
+            "sp.def": 35,
+            "speed": 35,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Gurdurr": {
+        "name": "Gurdurr",
+        "species": "Muscular Pokemon",
+        "id": "533",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.2m)",
+        "weight": "(40 kg)",
+        "abilities": [
+            "Guts",
+            "Sheer Force",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 105,
+            "defense": 85,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 40,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Conkeldurr": {
+        "name": "Conkeldurr",
+        "species": "Muscular Pokemon",
+        "id": "534",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.4m)",
+        "weight": "(87 kg)",
+        "abilities": [
+            "Guts",
+            "Sheer Force",
+            "Iron Fist"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 140,
+            "defense": 95,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 505
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tympole": {
+        "name": "Tympole",
+        "species": "Tadpole Pokemon",
+        "id": "535",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(4.5 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Hydration",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 40,
+            "sp.atk": 50,
+            "sp.def": 40,
+            "speed": 64,
+            "total": 294
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Palpitoad": {
+        "name": "Palpitoad",
+        "species": "Vibration Pokemon",
+        "id": "536",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(0.8m)",
+        "weight": "(17 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Hydration",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 65,
+            "defense": 55,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 69,
+            "total": 384
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Seismitoad": {
+        "name": "Seismitoad",
+        "species": "Vibration Pokemon",
+        "id": "537",
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "height": "(1.5m)",
+        "weight": "(62 kg)",
+        "abilities": [
+            "Swift Swim",
+            "Poison Touch",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 95,
+            "defense": 75,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 74,
+            "total": 509
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Throh": {
+        "name": "Throh",
+        "species": "Judo Pokemon",
+        "id": "538",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.3m)",
+        "weight": "(55.5 kg)",
+        "abilities": [
+            "Guts",
+            "Inner Focus",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 120,
+            "attack": 100,
+            "defense": 85,
+            "sp.atk": 30,
+            "sp.def": 85,
+            "speed": 45,
+            "total": 465
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Sawk": {
+        "name": "Sawk",
+        "species": "Karate Pokemon",
+        "id": "539",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.4m)",
+        "weight": "(51 kg)",
+        "abilities": [
+            "Sturdy",
+            "Inner Focus",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 125,
+            "defense": 75,
+            "sp.atk": 30,
+            "sp.def": 75,
+            "speed": 85,
+            "total": 465
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Sewaddle": {
+        "name": "Sewaddle",
+        "species": "Sewing Pokemon",
+        "id": "540",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Chlorophyll",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 53,
+            "defense": 70,
+            "sp.atk": 40,
+            "sp.def": 60,
+            "speed": 42,
+            "total": 310
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Swadloon": {
+        "name": "Swadloon",
+        "species": "Leaf-Wrapped Pokemon",
+        "id": "541",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(7.3 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Chlorophyll",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 63,
+            "defense": 90,
+            "sp.atk": 50,
+            "sp.def": 80,
+            "speed": 42,
+            "total": 380
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Leavanny": {
+        "name": "Leavanny",
+        "species": "Nurturing Pokemon",
+        "id": "542",
+        "type": [
+            "Bug",
+            "Grass"
+        ],
+        "height": "(1.2m)",
+        "weight": "(20.5 kg)",
+        "abilities": [
+            "Swarm",
+            "Chlorophyll",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 103,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 80,
+            "speed": 92,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Venipede": {
+        "name": "Venipede",
+        "species": "Centipede Pokemon",
+        "id": "543",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.3 kg)",
+        "abilities": [
+            "Poison Point",
+            "Swarm",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 30,
+            "attack": 45,
+            "defense": 59,
+            "sp.atk": 30,
+            "sp.def": 39,
+            "speed": 57,
+            "total": 260
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Whirlipede": {
+        "name": "Whirlipede",
+        "species": "Curlipede Pokemon",
+        "id": "544",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(1.2m)",
+        "weight": "(58.5 kg)",
+        "abilities": [
+            "Poison Point",
+            "Swarm",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 99,
+            "sp.atk": 40,
+            "sp.def": 79,
+            "speed": 47,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Scolipede": {
+        "name": "Scolipede",
+        "species": "Megapede Pokemon",
+        "id": "545",
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "height": "(2.5m)",
+        "weight": "(200.5 kg)",
+        "abilities": [
+            "Poison Point",
+            "Swarm",
+            "Speed Boost"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 100,
+            "defense": 89,
+            "sp.atk": 55,
+            "sp.def": 69,
+            "speed": 112,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cottonee": {
+        "name": "Cottonee",
+        "species": "Cotton Puff Pokemon",
+        "id": "546",
+        "type": [
+            "Grass",
+            "Fairy"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.6 kg)",
+        "abilities": [
+            "Prankster",
+            "Infiltrator",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 27,
+            "defense": 60,
+            "sp.atk": 37,
+            "sp.def": 50,
+            "speed": 66,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Whimsicott": {
+        "name": "Whimsicott",
+        "species": "Windveiled Pokemon",
+        "id": "547",
+        "type": [
+            "Grass",
+            "Fairy"
+        ],
+        "height": "(0.7m)",
+        "weight": "(6.6 kg)",
+        "abilities": [
+            "Prankster",
+            "Infiltrator",
+            "Chlorophyll"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 67,
+            "defense": 85,
+            "sp.atk": 77,
+            "sp.def": 75,
+            "speed": 116,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Petilil": {
+        "name": "Petilil",
+        "species": "Bulb Pokemon",
+        "id": "548",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.5m)",
+        "weight": "(6.6 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Own Tempo",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 35,
+            "defense": 50,
+            "sp.atk": 70,
+            "sp.def": 50,
+            "speed": 30,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Lilligant": {
+        "name": "Lilligant",
+        "species": "Flowering Pokemon",
+        "id": "549",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.1m)",
+        "weight": "(16.3 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Own Tempo",
+            "Leaf Guard"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 60,
+            "defense": 75,
+            "sp.atk": 110,
+            "sp.def": 75,
+            "speed": 90,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Basculin": {
+        "name": "Basculin",
+        "species": "Hostile Pokemon",
+        "id": "550",
+        "type": [
+            "Water"
+        ],
+        "height": "(1m)",
+        "weight": "(18 kg)",
+        "abilities": [
+            "Reckless",
+            "Rock Head",
+            "Adaptability",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 92,
+            "defense": 65,
+            "sp.atk": 80,
+            "sp.def": 55,
+            "speed": 98,
+            "total": 460
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Sandile": {
+        "name": "Sandile",
+        "species": "Desert Croc Pokemon",
+        "id": "551",
+        "type": [
+            "Ground",
+            "Dark"
+        ],
+        "height": "(0.7m)",
+        "weight": "(15.2 kg)",
+        "abilities": [
+            "Intimidate",
+            "Moxie",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 72,
+            "defense": 35,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 65,
+            "total": 292
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Krokorok": {
+        "name": "Krokorok",
+        "species": "Desert Croc Pokemon",
+        "id": "552",
+        "type": [
+            "Ground",
+            "Dark"
+        ],
+        "height": "(1m)",
+        "weight": "(33.4 kg)",
+        "abilities": [
+            "Intimidate",
+            "Moxie",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 82,
+            "defense": 45,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 74,
+            "total": 351
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Krookodile": {
+        "name": "Krookodile",
+        "species": "Intimidation Pokemon",
+        "id": "553",
+        "type": [
+            "Ground",
+            "Dark"
+        ],
+        "height": "(1.5m)",
+        "weight": "(96.3 kg)",
+        "abilities": [
+            "Intimidate",
+            "Moxie",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 117,
+            "defense": 80,
+            "sp.atk": 65,
+            "sp.def": 70,
+            "speed": 92,
+            "total": 519
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Darumaka": {
+        "name": "Darumaka",
+        "species": "Zen Charm Pokemon",
+        "id": "554",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.6m)",
+        "weight": "(37.5 kg)",
+        "abilities": [
+            "Hustle",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 90,
+            "defense": 45,
+            "sp.atk": 15,
+            "sp.def": 45,
+            "speed": 50,
+            "total": 315
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Darmanitan": {
+        "name": "Darmanitan",
+        "species": "Blazing Pokemon",
+        "id": "555",
+        "type": [
+            "Fire",
+            "Fire"
+        ],
+        "height": "(1.3m)",
+        "weight": "(92.9 kg)",
+        "abilities": [
+            "Sheer Force",
+            "Zen Mode"
+        ],
+        "stats": {
+            "hp": 105,
+            "attack": 30,
+            "defense": 105,
+            "sp.atk": 140,
+            "sp.def": 105,
+            "speed": 55,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Maractus": {
+        "name": "Maractus",
+        "species": "Cactus Pokemon",
+        "id": "556",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Water Absorb",
+            "Chlorophyll",
+            "Storm Drain"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 86,
+            "defense": 67,
+            "sp.atk": 106,
+            "sp.def": 67,
+            "speed": 60,
+            "total": 461
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Dwebble": {
+        "name": "Dwebble",
+        "species": "Rock Inn Pokemon",
+        "id": "557",
+        "type": [
+            "Bug",
+            "Rock"
+        ],
+        "height": "(0.3m)",
+        "weight": "(14.5 kg)",
+        "abilities": [
+            "Sturdy",
+            "Shell Armor",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 65,
+            "defense": 85,
+            "sp.atk": 35,
+            "sp.def": 35,
+            "speed": 55,
+            "total": 325
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Crustle": {
+        "name": "Crustle",
+        "species": "Stone Home Pokemon",
+        "id": "558",
+        "type": [
+            "Bug",
+            "Rock"
+        ],
+        "height": "(1.4m)",
+        "weight": "(200 kg)",
+        "abilities": [
+            "Sturdy",
+            "Shell Armor",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 105,
+            "defense": 125,
+            "sp.atk": 65,
+            "sp.def": 75,
+            "speed": 45,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Scraggy": {
+        "name": "Scraggy",
+        "species": "Shedding Pokemon",
+        "id": "559",
+        "type": [
+            "Dark",
+            "Fighting"
+        ],
+        "height": "(0.6m)",
+        "weight": "(11.8 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Moxie",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 75,
+            "defense": 70,
+            "sp.atk": 35,
+            "sp.def": 70,
+            "speed": 48,
+            "total": 348
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Scrafty": {
+        "name": "Scrafty",
+        "species": "Hoodlum Pokemon",
+        "id": "560",
+        "type": [
+            "Dark",
+            "Fighting"
+        ],
+        "height": "(1.1m)",
+        "weight": "(30 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Moxie",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 90,
+            "defense": 115,
+            "sp.atk": 45,
+            "sp.def": 115,
+            "speed": 58,
+            "total": 488
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Sigilyph": {
+        "name": "Sigilyph",
+        "species": "Avianoid Pokemon",
+        "id": "561",
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "height": "(1.4m)",
+        "weight": "(14 kg)",
+        "abilities": [
+            "Wonder Skin ",
+            "Magic Guard",
+            "Tinted Lens"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 58,
+            "defense": 80,
+            "sp.atk": 103,
+            "sp.def": 80,
+            "speed": 97,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Yamask": {
+        "name": "Yamask",
+        "species": "Spirit Pokemon",
+        "id": "562",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(0.5m)",
+        "weight": "(1.5 kg)",
+        "abilities": [
+            "Mummy"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 30,
+            "defense": 85,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 30,
+            "total": 303
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cofagrigus": {
+        "name": "Cofagrigus",
+        "species": "Coffin Pokemon",
+        "id": "563",
+        "type": [
+            "Ghost"
+        ],
+        "height": "(1.7m)",
+        "weight": "(76.5 kg)",
+        "abilities": [
+            "Mummy"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 50,
+            "defense": 145,
+            "sp.atk": 95,
+            "sp.def": 105,
+            "speed": 30,
+            "total": 483
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tirtouga": {
+        "name": "Tirtouga",
+        "species": "Prototurtle Pokemon",
+        "id": "564",
+        "type": [
+            "Water",
+            "Rock"
+        ],
+        "height": "(0.7m)",
+        "weight": "(16.5 kg)",
+        "abilities": [
+            "Solid Rock",
+            "Sturdy",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 54,
+            "attack": 78,
+            "defense": 103,
+            "sp.atk": 53,
+            "sp.def": 45,
+            "speed": 22,
+            "total": 355
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Carracosta": {
+        "name": "Carracosta",
+        "species": "Prototurtle Pokemon",
+        "id": "565",
+        "type": [
+            "Water",
+            "Rock"
+        ],
+        "height": "(1.2m)",
+        "weight": "(81 kg)",
+        "abilities": [
+            "Solid Rock",
+            "Sturdy",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 74,
+            "attack": 108,
+            "defense": 133,
+            "sp.atk": 83,
+            "sp.def": 65,
+            "speed": 32,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Archen": {
+        "name": "Archen",
+        "species": "First Bird Pokemon",
+        "id": "566",
+        "type": [
+            "Rock",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9.5 kg)",
+        "abilities": [
+            "Defeatist"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 112,
+            "defense": 45,
+            "sp.atk": 74,
+            "sp.def": 45,
+            "speed": 70,
+            "total": 401
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Archeops": {
+        "name": "Archeops",
+        "species": "First Bird Pokemon",
+        "id": "567",
+        "type": [
+            "Rock",
+            "Flying"
+        ],
+        "height": "(1.4m)",
+        "weight": "(32 kg)",
+        "abilities": [
+            "Defeatist"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 140,
+            "defense": 65,
+            "sp.atk": 112,
+            "sp.def": 65,
+            "speed": 110,
+            "total": 567
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Trubbish": {
+        "name": "Trubbish",
+        "species": "Trash Bag Pokemon",
+        "id": "568",
+        "type": [
+            "Poison"
+        ],
+        "height": "(0.6m)",
+        "weight": "(31 kg)",
+        "abilities": [
+            "Stench",
+            "Sticky Hold",
+            "Aftermath"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 62,
+            "sp.atk": 40,
+            "sp.def": 62,
+            "speed": 65,
+            "total": 329
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Garbodor": {
+        "name": "Garbodor",
+        "species": "Trash Heap Pokemon",
+        "id": "569",
+        "type": [
+            "Poison"
+        ],
+        "height": "(1.9m)",
+        "weight": "(107.3 kg)",
+        "abilities": [
+            "Stench",
+            "Weak Armor",
+            "Aftermath"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 95,
+            "defense": 82,
+            "sp.atk": 60,
+            "sp.def": 82,
+            "speed": 75,
+            "total": 474
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Zorua": {
+        "name": "Zorua",
+        "species": "Tricky Fox Pokemon",
+        "id": "570",
+        "type": [
+            "Dark"
+        ],
+        "height": "(0.7m)",
+        "weight": "(12.5 kg)",
+        "abilities": [
+            "Illusion"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 65,
+            "defense": 40,
+            "sp.atk": 80,
+            "sp.def": 40,
+            "speed": 65,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Zoroark": {
+        "name": "Zoroark",
+        "species": "Illusion Fox Pokemon",
+        "id": "571",
+        "type": [
+            "Dark"
+        ],
+        "height": "(1.6m)",
+        "weight": "(81.1 kg)",
+        "abilities": [
+            "Illusion"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 105,
+            "defense": 60,
+            "sp.atk": 120,
+            "sp.def": 60,
+            "speed": 105,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Minccino": {
+        "name": "Minccino",
+        "species": "Chinchilla Pokemon",
+        "id": "572",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.8 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Technician",
+            "Skill Link"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 50,
+            "defense": 40,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 75,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cinccino": {
+        "name": "Cinccino",
+        "species": "Scarf Pokemon",
+        "id": "573",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(7.5 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Technician",
+            "Skill Link"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 95,
+            "defense": 60,
+            "sp.atk": 65,
+            "sp.def": 60,
+            "speed": 115,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Gothita": {
+        "name": "Gothita",
+        "species": "Fixation Pokemon",
+        "id": "574",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.8 kg)",
+        "abilities": [
+            "Frisk",
+            "Competitive",
+            "Shadow Tag"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 30,
+            "defense": 50,
+            "sp.atk": 55,
+            "sp.def": 65,
+            "speed": 45,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Gothorita": {
+        "name": "Gothorita",
+        "species": "Manipulate Pokemon",
+        "id": "575",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.7m)",
+        "weight": "(18 kg)",
+        "abilities": [
+            "Frisk",
+            "Competitive",
+            "Shadow Tag"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 45,
+            "defense": 70,
+            "sp.atk": 75,
+            "sp.def": 85,
+            "speed": 55,
+            "total": 390
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Gothitelle": {
+        "name": "Gothitelle",
+        "species": "Astral Body Pokemon",
+        "id": "576",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(44 kg)",
+        "abilities": [
+            "Frisk",
+            "Competitive",
+            "Shadow Tag"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 55,
+            "defense": 95,
+            "sp.atk": 95,
+            "sp.def": 110,
+            "speed": 65,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Solosis": {
+        "name": "Solosis",
+        "species": "Cell Pokemon",
+        "id": "577",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Overcoat",
+            "Magic Guard",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 30,
+            "defense": 40,
+            "sp.atk": 105,
+            "sp.def": 50,
+            "speed": 20,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Duosion": {
+        "name": "Duosion",
+        "species": "Mitosis Pokemon",
+        "id": "578",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8 kg)",
+        "abilities": [
+            "Overcoat",
+            "Magic Guard",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 40,
+            "defense": 50,
+            "sp.atk": 125,
+            "sp.def": 60,
+            "speed": 30,
+            "total": 370
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Reuniclus": {
+        "name": "Reuniclus",
+        "species": "Multiplying Pokemon",
+        "id": "579",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1m)",
+        "weight": "(20.1 kg)",
+        "abilities": [
+            "Overcoat",
+            "Magic Guard",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 65,
+            "defense": 75,
+            "sp.atk": 125,
+            "sp.def": 85,
+            "speed": 30,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Ducklett": {
+        "name": "Ducklett",
+        "species": "Water Bird Pokemon",
+        "id": "580",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Big Pecks",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 44,
+            "defense": 50,
+            "sp.atk": 44,
+            "sp.def": 50,
+            "speed": 55,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Swanna": {
+        "name": "Swanna",
+        "species": "White Bird Pokemon",
+        "id": "581",
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "height": "(1.3m)",
+        "weight": "(24.2 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Big Pecks",
+            "Hydration"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 87,
+            "defense": 63,
+            "sp.atk": 87,
+            "sp.def": 63,
+            "speed": 98,
+            "total": 473
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Vanillite": {
+        "name": "Vanillite",
+        "species": "Fresh Snow Pokemon",
+        "id": "582",
+        "type": [
+            "Ice"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5.7 kg)",
+        "abilities": [
+            "Ice Body",
+            "Snow Cloak",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 36,
+            "attack": 50,
+            "defense": 50,
+            "sp.atk": 65,
+            "sp.def": 60,
+            "speed": 44,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Vanillish": {
+        "name": "Vanillish",
+        "species": "Icy Snow Pokemon",
+        "id": "583",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1.1m)",
+        "weight": "(41 kg)",
+        "abilities": [
+            "Ice Body",
+            "Snow Cloak",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 51,
+            "attack": 65,
+            "defense": 65,
+            "sp.atk": 80,
+            "sp.def": 75,
+            "speed": 59,
+            "total": 395
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Vanilluxe": {
+        "name": "Vanilluxe",
+        "species": "Snowstorm Pokemon",
+        "id": "584",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1.3m)",
+        "weight": "(57.5 kg)",
+        "abilities": [
+            "Ice Body",
+            "Snow Warning",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 71,
+            "attack": 95,
+            "defense": 85,
+            "sp.atk": 110,
+            "sp.def": 95,
+            "speed": 79,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Deerling": {
+        "name": "Deerling",
+        "species": "Season Pokemon",
+        "id": "585",
+        "type": [
+            "Normal",
+            "Grass"
+        ],
+        "height": "(0.6m)",
+        "weight": "(19.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Sap Sipper",
+            "Serene Grace"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 60,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 75,
+            "total": 335
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Sawsbuck": {
+        "name": "Sawsbuck",
+        "species": "Season Pokemon",
+        "id": "586",
+        "type": [
+            "Normal",
+            "Grass"
+        ],
+        "height": "(1.9m)",
+        "weight": "(92.5 kg)",
+        "abilities": [
+            "Chlorophyll",
+            "Sap Sipper",
+            "Serene Grace"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 100,
+            "defense": 70,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 95,
+            "total": 475
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Emolga": {
+        "name": "Emolga",
+        "species": "Sky Squirrel Pokemon",
+        "id": "587",
+        "type": [
+            "Electric",
+            "Flying"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Static",
+            "Motor Drive"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 75,
+            "defense": 60,
+            "sp.atk": 75,
+            "sp.def": 60,
+            "speed": 103,
+            "total": 428
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Karrablast": {
+        "name": "Karrablast",
+        "species": "Clamping Pokemon",
+        "id": "588",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.5m)",
+        "weight": "(5.9 kg)",
+        "abilities": [
+            "Swarm",
+            "Shed Skin",
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 75,
+            "defense": 45,
+            "sp.atk": 40,
+            "sp.def": 45,
+            "speed": 60,
+            "total": 315
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Escavalier": {
+        "name": "Escavalier",
+        "species": "Cavalry Pokemon",
+        "id": "589",
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "height": "(1m)",
+        "weight": "(33 kg)",
+        "abilities": [
+            "Swarm",
+            "Shell Armor",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 135,
+            "defense": 105,
+            "sp.atk": 60,
+            "sp.def": 105,
+            "speed": 20,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Foongus": {
+        "name": "Foongus",
+        "species": "Mushroom Pokemon",
+        "id": "590",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "(0.2m)",
+        "weight": "(1 kg)",
+        "abilities": [
+            "Effect Spore",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 69,
+            "attack": 55,
+            "defense": 45,
+            "sp.atk": 55,
+            "sp.def": 55,
+            "speed": 15,
+            "total": 294
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Amoonguss": {
+        "name": "Amoonguss",
+        "species": "Mushroom Pokemon",
+        "id": "591",
+        "type": [
+            "Grass",
+            "Poison"
+        ],
+        "height": "(0.6m)",
+        "weight": "(10.5 kg)",
+        "abilities": [
+            "Effect Spore",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 114,
+            "attack": 85,
+            "defense": 70,
+            "sp.atk": 85,
+            "sp.def": 80,
+            "speed": 30,
+            "total": 464
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Frillish": {
+        "name": "Frillish",
+        "species": "Floating Pokemon",
+        "id": "592",
+        "type": [
+            "Water",
+            "Ghost"
+        ],
+        "height": "(1.2m)",
+        "weight": "(33 kg)",
+        "abilities": [
+            "Water Absorb",
+            "Cursed Body",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 40,
+            "defense": 50,
+            "sp.atk": 65,
+            "sp.def": 85,
+            "speed": 40,
+            "total": 335
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Jellicent": {
+        "name": "Jellicent",
+        "species": "Floating Pokemon",
+        "id": "593",
+        "type": [
+            "Water",
+            "Ghost"
+        ],
+        "height": "(2.2m)",
+        "weight": "(135 kg)",
+        "abilities": [
+            "Water Absorb",
+            "Cursed Body",
+            "Damp"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 60,
+            "defense": 70,
+            "sp.atk": 85,
+            "sp.def": 105,
+            "speed": 60,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Alomomola": {
+        "name": "Alomomola",
+        "species": "Caring Pokemon",
+        "id": "594",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.2m)",
+        "weight": "(31.6 kg)",
+        "abilities": [
+            "Healer",
+            "Hydration",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 165,
+            "attack": 75,
+            "defense": 80,
+            "sp.atk": 40,
+            "sp.def": 45,
+            "speed": 65,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Joltik": {
+        "name": "Joltik",
+        "species": "Attaching Pokemon",
+        "id": "595",
+        "type": [
+            "Bug",
+            "Electric"
+        ],
+        "height": "(0.1m)",
+        "weight": "(0.6 kg)",
+        "abilities": [
+            "Compoundeyes",
+            "Unnerve",
+            "Swarm"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 47,
+            "defense": 50,
+            "sp.atk": 57,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 319
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Galvantula": {
+        "name": "Galvantula",
+        "species": "EleSpider Pokemon",
+        "id": "596",
+        "type": [
+            "Bug",
+            "Electric"
+        ],
+        "height": "(0.8m)",
+        "weight": "(14.3 kg)",
+        "abilities": [
+            "Compoundeyes",
+            "Unnerve",
+            "Swarm"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 77,
+            "defense": 60,
+            "sp.atk": 97,
+            "sp.def": 60,
+            "speed": 108,
+            "total": 472
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Ferroseed": {
+        "name": "Ferroseed",
+        "species": "Thorn Seed Pokemon",
+        "id": "597",
+        "type": [
+            "Grass",
+            "Steel"
+        ],
+        "height": "(0.6m)",
+        "weight": "(18.8 kg)",
+        "abilities": [
+            "Iron Barbs"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 50,
+            "defense": 91,
+            "sp.atk": 24,
+            "sp.def": 86,
+            "speed": 10,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Ferrothorn": {
+        "name": "Ferrothorn",
+        "species": "Thorn Pod Pokemon",
+        "id": "598",
+        "type": [
+            "Grass",
+            "Steel"
+        ],
+        "height": "(1m)",
+        "weight": "(110 kg)",
+        "abilities": [
+            "Iron Barbs",
+            "Anticipation"
+        ],
+        "stats": {
+            "hp": 74,
+            "attack": 94,
+            "defense": 131,
+            "sp.atk": 54,
+            "sp.def": 116,
+            "speed": 20,
+            "total": 489
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Klink": {
+        "name": "Klink",
+        "species": "Gear Pokemon",
+        "id": "599",
+        "type": [
+            "Steel"
+        ],
+        "height": "(0.3m)",
+        "weight": "(21 kg)",
+        "abilities": [
+            "Plus",
+            "Minus",
+            "Clear Body"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 70,
+            "sp.atk": 45,
+            "sp.def": 60,
+            "speed": 30,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Klang": {
+        "name": "Klang",
+        "species": "Gear Pokemon",
+        "id": "600",
+        "type": [
+            "Steel"
+        ],
+        "height": "(0.6m)",
+        "weight": "(51 kg)",
+        "abilities": [
+            "Plus",
+            "Minus",
+            "Clear Body"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 80,
+            "defense": 95,
+            "sp.atk": 70,
+            "sp.def": 85,
+            "speed": 50,
+            "total": 440
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Klinklang": {
+        "name": "Klinklang",
+        "species": "Gear Pokemon",
+        "id": "601",
+        "type": [
+            "Steel"
+        ],
+        "height": "(0.6m)",
+        "weight": "(81 kg)",
+        "abilities": [
+            "Plus",
+            "Minus",
+            "Clear Body"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 100,
+            "defense": 115,
+            "sp.atk": 70,
+            "sp.def": 85,
+            "speed": 90,
+            "total": 520
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tynamo": {
+        "name": "Tynamo",
+        "species": "EleFish Pokemon",
+        "id": "602",
+        "type": [
+            "Electric"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 55,
+            "defense": 40,
+            "sp.atk": 45,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 275
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Eelektrik": {
+        "name": "Eelektrik",
+        "species": "EleFish Pokemon",
+        "id": "603",
+        "type": [
+            "Electric"
+        ],
+        "height": "(1.2m)",
+        "weight": "(22 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 85,
+            "defense": 70,
+            "sp.atk": 75,
+            "sp.def": 70,
+            "speed": 40,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Eelektross": {
+        "name": "Eelektross",
+        "species": "EleFish Pokemon",
+        "id": "604",
+        "type": [
+            "Electric"
+        ],
+        "height": "(2.1m)",
+        "weight": "(80.5 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 115,
+            "defense": 80,
+            "sp.atk": 105,
+            "sp.def": 80,
+            "speed": 50,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Elgyem": {
+        "name": "Elgyem",
+        "species": "Cerebral Pokemon",
+        "id": "605",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9 kg)",
+        "abilities": [
+            "Telepathy",
+            "Synchronize",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 55,
+            "defense": 55,
+            "sp.atk": 85,
+            "sp.def": 55,
+            "speed": 30,
+            "total": 335
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Beheeyem": {
+        "name": "Beheeyem",
+        "species": "Cerebral Pokemon",
+        "id": "606",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(1m)",
+        "weight": "(34.5 kg)",
+        "abilities": [
+            "Telepathy",
+            "Synchronize",
+            "Analytic"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 75,
+            "defense": 75,
+            "sp.atk": 125,
+            "sp.def": 95,
+            "speed": 40,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Litwick": {
+        "name": "Litwick",
+        "species": "Candle Pokemon",
+        "id": "607",
+        "type": [
+            "Ghost",
+            "Fire"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3.1 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Flame Body",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 30,
+            "defense": 55,
+            "sp.atk": 65,
+            "sp.def": 55,
+            "speed": 20,
+            "total": 275
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Lampent": {
+        "name": "Lampent",
+        "species": "Lamp Pokemon",
+        "id": "608",
+        "type": [
+            "Ghost",
+            "Fire"
+        ],
+        "height": "(0.6m)",
+        "weight": "(13 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Flame Body",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 40,
+            "defense": 60,
+            "sp.atk": 95,
+            "sp.def": 60,
+            "speed": 55,
+            "total": 370
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Chandelure": {
+        "name": "Chandelure",
+        "species": "Luring Pokemon",
+        "id": "609",
+        "type": [
+            "Ghost",
+            "Fire"
+        ],
+        "height": "(1m)",
+        "weight": "(34.3 kg)",
+        "abilities": [
+            "Flash Fire",
+            "Flame Body",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 55,
+            "defense": 90,
+            "sp.atk": 145,
+            "sp.def": 90,
+            "speed": 80,
+            "total": 520
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Axew": {
+        "name": "Axew",
+        "species": "Tusk Pokemon",
+        "id": "610",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(0.6m)",
+        "weight": "(18 kg)",
+        "abilities": [
+            "Rivalry",
+            "Mold Breaker",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 46,
+            "attack": 87,
+            "defense": 60,
+            "sp.atk": 30,
+            "sp.def": 40,
+            "speed": 57,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Fraxure": {
+        "name": "Fraxure",
+        "species": "Axe Jaw Pokemon",
+        "id": "611",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(1m)",
+        "weight": "(36 kg)",
+        "abilities": [
+            "Rivalry",
+            "Mold Breaker",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 66,
+            "attack": 117,
+            "defense": 70,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 67,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Haxorus": {
+        "name": "Haxorus",
+        "species": "Axe Jaw Pokemon",
+        "id": "612",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(1.8m)",
+        "weight": "(105.5 kg)",
+        "abilities": [
+            "Rivalry",
+            "Mold Breaker",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 76,
+            "attack": 147,
+            "defense": 90,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 97,
+            "total": 540
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cubchoo": {
+        "name": "Cubchoo",
+        "species": "Chill Pokemon",
+        "id": "613",
+        "type": [
+            "Ice"
+        ],
+        "height": "(0.5m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Snow Cloak",
+            "Slush Rush",
+            "Rattled"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 70,
+            "defense": 40,
+            "sp.atk": 60,
+            "sp.def": 40,
+            "speed": 40,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Beartic": {
+        "name": "Beartic",
+        "species": "Freezing Pokemon",
+        "id": "614",
+        "type": [
+            "Ice"
+        ],
+        "height": "(2.6m)",
+        "weight": "(260 kg)",
+        "abilities": [
+            "Snow Cloak",
+            "Slush Rush",
+            "Swift Swim"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 130,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 80,
+            "speed": 50,
+            "total": 505
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cryogonal": {
+        "name": "Cryogonal",
+        "species": "Crystallizing Pokemon",
+        "id": "615",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1.1m)",
+        "weight": "(148 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 50,
+            "defense": 50,
+            "sp.atk": 95,
+            "sp.def": 135,
+            "speed": 105,
+            "total": 515
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Shelmet": {
+        "name": "Shelmet",
+        "species": "Snail Pokemon",
+        "id": "616",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.4m)",
+        "weight": "(7.7 kg)",
+        "abilities": [
+            "Hydration",
+            "Shell Armor",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 40,
+            "defense": 85,
+            "sp.atk": 40,
+            "sp.def": 65,
+            "speed": 25,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Accelgor": {
+        "name": "Accelgor",
+        "species": "Shell Out Pokemon",
+        "id": "617",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.8m)",
+        "weight": "(25.3 kg)",
+        "abilities": [
+            "Hydration",
+            "Sticky Hold",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 70,
+            "defense": 40,
+            "sp.atk": 100,
+            "sp.def": 60,
+            "speed": 145,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Stunfisk": {
+        "name": "Stunfisk",
+        "species": "Trap Pokemon",
+        "id": "618",
+        "type": [
+            "Ground",
+            "Electric"
+        ],
+        "height": "(0.7m)",
+        "weight": "(11 kg)",
+        "abilities": [
+            "Static",
+            "Limber",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 109,
+            "attack": 66,
+            "defense": 84,
+            "sp.atk": 81,
+            "sp.def": 99,
+            "speed": 32,
+            "total": 471
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Mienfoo": {
+        "name": "Mienfoo",
+        "species": "Martial Arts Pokemon",
+        "id": "619",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.9m)",
+        "weight": "(20 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Regenerator",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 85,
+            "defense": 50,
+            "sp.atk": 55,
+            "sp.def": 50,
+            "speed": 65,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Mienshao": {
+        "name": "Mienshao",
+        "species": "Martial Arts Pokemon",
+        "id": "620",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(1.4m)",
+        "weight": "(35.5 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Regenerator",
+            "Reckless"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 125,
+            "defense": 60,
+            "sp.atk": 95,
+            "sp.def": 60,
+            "speed": 105,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Druddigon": {
+        "name": "Druddigon",
+        "species": "Cave Pokemon",
+        "id": "621",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(1.6m)",
+        "weight": "(139 kg)",
+        "abilities": [
+            "Rough Skin",
+            "Sheer Force",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 77,
+            "attack": 120,
+            "defense": 90,
+            "sp.atk": 60,
+            "sp.def": 90,
+            "speed": 48,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Golett": {
+        "name": "Golett",
+        "species": "Automaton Pokemon",
+        "id": "622",
+        "type": [
+            "Ground",
+            "Ghost"
+        ],
+        "height": "(1m)",
+        "weight": "(92 kg)",
+        "abilities": [
+            "Iron Fist",
+            "Klutz",
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 74,
+            "defense": 50,
+            "sp.atk": 35,
+            "sp.def": 50,
+            "speed": 35,
+            "total": 303
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Golurk": {
+        "name": "Golurk",
+        "species": "Automaton Pokemon",
+        "id": "623",
+        "type": [
+            "Ground",
+            "Ghost"
+        ],
+        "height": "(2.8m)",
+        "weight": "(330 kg)",
+        "abilities": [
+            "Iron Fist",
+            "Klutz",
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 89,
+            "attack": 124,
+            "defense": 80,
+            "sp.atk": 55,
+            "sp.def": 80,
+            "speed": 55,
+            "total": 483
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Pawniard": {
+        "name": "Pawniard",
+        "species": "Sharp Blade Pokemon",
+        "id": "624",
+        "type": [
+            "Dark",
+            "Steel"
+        ],
+        "height": "(0.5m)",
+        "weight": "(10.2 kg)",
+        "abilities": [
+            "Defiant",
+            "Inner Focus",
+            "Pressure"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 85,
+            "defense": 70,
+            "sp.atk": 40,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Bisharp": {
+        "name": "Bisharp",
+        "species": "Sword Blade Pokemon",
+        "id": "625",
+        "type": [
+            "Dark",
+            "Steel"
+        ],
+        "height": "(1.6m)",
+        "weight": "(70 kg)",
+        "abilities": [
+            "Defiant",
+            "Inner Focus",
+            "Pressure"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 125,
+            "defense": 100,
+            "sp.atk": 60,
+            "sp.def": 70,
+            "speed": 70,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Bouffalant": {
+        "name": "Bouffalant",
+        "species": "Bash Buffalo Pokemon",
+        "id": "626",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.6m)",
+        "weight": "(94.6 kg)",
+        "abilities": [
+            "Reckless",
+            "Sap Sipper",
+            "Soundproof"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 110,
+            "defense": 95,
+            "sp.atk": 40,
+            "sp.def": 95,
+            "speed": 55,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Rufflet": {
+        "name": "Rufflet",
+        "species": "Eaglet Pokemon",
+        "id": "627",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(10.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sheer Force",
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 83,
+            "defense": 50,
+            "sp.atk": 37,
+            "sp.def": 50,
+            "speed": 60,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Braviary": {
+        "name": "Braviary",
+        "species": "Valiant Pokemon",
+        "id": "628",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(41 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sheer Force",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 123,
+            "defense": 75,
+            "sp.atk": 57,
+            "sp.def": 75,
+            "speed": 80,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Vullaby": {
+        "name": "Vullaby",
+        "species": "Diapered Pokemon",
+        "id": "629",
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Overcoat",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 55,
+            "defense": 75,
+            "sp.atk": 45,
+            "sp.def": 65,
+            "speed": 60,
+            "total": 370
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Mandibuzz": {
+        "name": "Mandibuzz",
+        "species": "Bone Vulture Pokemon",
+        "id": "630",
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(39.5 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Overcoat",
+            "Weak Armor"
+        ],
+        "stats": {
+            "hp": 110,
+            "attack": 65,
+            "defense": 105,
+            "sp.atk": 55,
+            "sp.def": 95,
+            "speed": 80,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Heatmor": {
+        "name": "Heatmor",
+        "species": "Anteater Pokemon",
+        "id": "631",
+        "type": [
+            "Fire"
+        ],
+        "height": "(1.4m)",
+        "weight": "(58 kg)",
+        "abilities": [
+            "Gluttony",
+            "Flash Fire",
+            "White Smoke"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 97,
+            "defense": 66,
+            "sp.atk": 105,
+            "sp.def": 66,
+            "speed": 65,
+            "total": 484
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Durant": {
+        "name": "Durant",
+        "species": "Iron Ant Pokemon",
+        "id": "632",
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "height": "(0.3m)",
+        "weight": "(33 kg)",
+        "abilities": [
+            "Swarm",
+            "Hustle",
+            "Truant"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 109,
+            "defense": 112,
+            "sp.atk": 48,
+            "sp.def": 48,
+            "speed": 109,
+            "total": 484
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Deino": {
+        "name": "Deino",
+        "species": "Irate Pokemon",
+        "id": "633",
+        "type": [
+            "Dark",
+            "Dragon"
+        ],
+        "height": "(0.8m)",
+        "weight": "(17.3 kg)",
+        "abilities": [
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 52,
+            "attack": 65,
+            "defense": 50,
+            "sp.atk": 45,
+            "sp.def": 50,
+            "speed": 38,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Zweilous": {
+        "name": "Zweilous",
+        "species": "Hostile Pokemon",
+        "id": "634",
+        "type": [
+            "Dark",
+            "Dragon"
+        ],
+        "height": "(1.4m)",
+        "weight": "(50 kg)",
+        "abilities": [
+            "Hustle"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 85,
+            "defense": 70,
+            "sp.atk": 65,
+            "sp.def": 70,
+            "speed": 58,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Hydreigon": {
+        "name": "Hydreigon",
+        "species": "Brutal Pokemon",
+        "id": "635",
+        "type": [
+            "Dark",
+            "Dragon"
+        ],
+        "height": "(1.8m)",
+        "weight": "(160 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 92,
+            "attack": 105,
+            "defense": 90,
+            "sp.atk": 125,
+            "sp.def": 90,
+            "speed": 98,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Larvesta": {
+        "name": "Larvesta",
+        "species": "Torch Pokemon",
+        "id": "636",
+        "type": [
+            "Bug",
+            "Fire"
+        ],
+        "height": "(1.1m)",
+        "weight": "(28.8 kg)",
+        "abilities": [
+            "Flame Body",
+            "Swarm"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 85,
+            "defense": 55,
+            "sp.atk": 50,
+            "sp.def": 55,
+            "speed": 60,
+            "total": 360
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Volcarona": {
+        "name": "Volcarona",
+        "species": "Sun Pokemon",
+        "id": "637",
+        "type": [
+            "Bug",
+            "Fire"
+        ],
+        "height": "(1.6m)",
+        "weight": "(46 kg)",
+        "abilities": [
+            "Flame Body",
+            "Swarm"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 60,
+            "defense": 65,
+            "sp.atk": 135,
+            "sp.def": 105,
+            "speed": 100,
+            "total": 550
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Cobalion": {
+        "name": "Cobalion",
+        "species": "Iron Will Pokemon",
+        "id": "638",
+        "type": [
+            "Steel",
+            "Fighting"
+        ],
+        "height": "(2.1m)",
+        "weight": "(250 kg)",
+        "abilities": [
+            "Justified"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 90,
+            "defense": 129,
+            "sp.atk": 90,
+            "sp.def": 72,
+            "speed": 108,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Terrakion": {
+        "name": "Terrakion",
+        "species": "Cavern Pokemon",
+        "id": "639",
+        "type": [
+            "Rock",
+            "Fighting"
+        ],
+        "height": "(1.9m)",
+        "weight": "(260 kg)",
+        "abilities": [
+            "Justified"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 129,
+            "defense": 90,
+            "sp.atk": 72,
+            "sp.def": 90,
+            "speed": 108,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Virizion": {
+        "name": "Virizion",
+        "species": "Grassland Pokemon",
+        "id": "640",
+        "type": [
+            "Grass",
+            "Fighting"
+        ],
+        "height": "(2m)",
+        "weight": "(200 kg)",
+        "abilities": [
+            "Justified"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 90,
+            "defense": 72,
+            "sp.atk": 90,
+            "sp.def": 129,
+            "speed": 108,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Tornadus": {
+        "name": "Tornadus",
+        "species": "Cyclone Pokemon",
+        "id": "641",
+        "type": [
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(63 kg)",
+        "abilities": [
+            "Prankster",
+            "Defiant",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 79,
+            "attack": 100,
+            "defense": 80,
+            "sp.atk": 110,
+            "sp.def": 90,
+            "speed": 121,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Thundurus": {
+        "name": "Thundurus",
+        "species": "Bolt Strike Pokemon",
+        "id": "642",
+        "type": [
+            "Electric",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(61 kg)",
+        "abilities": [
+            "Prankster",
+            "Defiant",
+            "Volt Absorb"
+        ],
+        "stats": {
+            "hp": 79,
+            "attack": 105,
+            "defense": 70,
+            "sp.atk": 145,
+            "sp.def": 80,
+            "speed": 101,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Reshiram": {
+        "name": "Reshiram",
+        "species": "Vast White Pokemon",
+        "id": "643",
+        "type": [
+            "Dragon",
+            "Fire"
+        ],
+        "height": "(3.2m)",
+        "weight": "(330 kg)",
+        "abilities": [
+            "Turboblaze"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 120,
+            "defense": 100,
+            "sp.atk": 150,
+            "sp.def": 120,
+            "speed": 90,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Zekrom": {
+        "name": "Zekrom",
+        "species": "Deep Black Pokemon",
+        "id": "644",
+        "type": [
+            "Dragon",
+            "Electric"
+        ],
+        "height": "(2.9m)",
+        "weight": "(345 kg)",
+        "abilities": [
+            "Teravolt"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 150,
+            "defense": 120,
+            "sp.atk": 120,
+            "sp.def": 100,
+            "speed": 90,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Landorus": {
+        "name": "Landorus",
+        "species": "Abundance Pokemon",
+        "id": "645",
+        "type": [
+            "Ground",
+            "Flying"
+        ],
+        "height": "(1.5m)",
+        "weight": "(68 kg)",
+        "abilities": [
+            "Sand Force",
+            "Sheer Force",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 89,
+            "attack": 145,
+            "defense": 90,
+            "sp.atk": 105,
+            "sp.def": 80,
+            "speed": 91,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Kyurem": {
+        "name": "Kyurem",
+        "species": "Boundary Pokemon",
+        "id": "646",
+        "type": [
+            "Dragon",
+            "Ice"
+        ],
+        "height": "(3m)",
+        "weight": "(325 kg)",
+        "abilities": [
+            "Pressure",
+            "Teravolt",
+            "Turboblaze"
+        ],
+        "stats": {
+            "hp": 125,
+            "attack": 120,
+            "defense": 90,
+            "sp.atk": 170,
+            "sp.def": 100,
+            "speed": 95,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Keldeo": {
+        "name": "Keldeo",
+        "species": "Colt Pokemon",
+        "id": "647",
+        "type": [
+            "Water",
+            "Fighting"
+        ],
+        "height": "(1.4m)",
+        "weight": "(48.5 kg)",
+        "abilities": [
+            "Justified"
+        ],
+        "stats": {
+            "hp": 91,
+            "attack": 72,
+            "defense": 90,
+            "sp.atk": 129,
+            "sp.def": 90,
+            "speed": 108,
+            "total": 580
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Meloetta": {
+        "name": "Meloetta",
+        "species": "Melody Pokemon",
+        "id": "648",
+        "type": [
+            "Normal",
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(6.5 kg)",
+        "abilities": [
+            "Serene Grace"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 128,
+            "defense": 90,
+            "sp.atk": 77,
+            "sp.def": 77,
+            "speed": 128,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Genesect": {
+        "name": "Genesect",
+        "species": "Paleozoic Pokemon",
+        "id": "649",
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "height": "(1.5m)",
+        "weight": "(82.5 kg)",
+        "abilities": [
+            "Download"
+        ],
+        "stats": {
+            "hp": 71,
+            "attack": 120,
+            "defense": 95,
+            "sp.atk": 120,
+            "sp.def": 95,
+            "speed": 99,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 5
+    },
+    "Chespin": {
+        "name": "Chespin",
+        "species": "Spiky Nut Pokemon",
+        "id": "650",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(9 kg)",
+        "abilities": [
+            "Overgrow",
+            "Bulletproof"
+        ],
+        "stats": {
+            "hp": 56,
+            "attack": 61,
+            "defense": 65,
+            "sp.atk": 48,
+            "sp.def": 45,
+            "speed": 38,
+            "total": 313
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Quilladin": {
+        "name": "Quilladin",
+        "species": "Spiny Armor Pokemon",
+        "id": "651",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.7m)",
+        "weight": "(29 kg)",
+        "abilities": [
+            "Overgrow",
+            "Bulletproof"
+        ],
+        "stats": {
+            "hp": 61,
+            "attack": 78,
+            "defense": 95,
+            "sp.atk": 56,
+            "sp.def": 58,
+            "speed": 57,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Chesnaught": {
+        "name": "Chesnaught",
+        "species": "Spiny Armor Pokemon",
+        "id": "652",
+        "type": [
+            "Grass",
+            "Fighting"
+        ],
+        "height": "(1.6m)",
+        "weight": "(90 kg)",
+        "abilities": [
+            "Overgrow",
+            "Bulletproof"
+        ],
+        "stats": {
+            "hp": 88,
+            "attack": 107,
+            "defense": 122,
+            "sp.atk": 74,
+            "sp.def": 75,
+            "speed": 64,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Fennekin": {
+        "name": "Fennekin",
+        "species": "Fox Pokemon",
+        "id": "653",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.4m)",
+        "weight": "(9.4 kg)",
+        "abilities": [
+            "Blaze",
+            "Magician"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 40,
+            "sp.atk": 62,
+            "sp.def": 60,
+            "speed": 60,
+            "total": 307
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Braixen": {
+        "name": "Braixen",
+        "species": "Fox Pokemon",
+        "id": "654",
+        "type": [
+            "Fire"
+        ],
+        "height": "(1m)",
+        "weight": "(14.5 kg)",
+        "abilities": [
+            "Blaze",
+            "Magician"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 59,
+            "defense": 58,
+            "sp.atk": 90,
+            "sp.def": 70,
+            "speed": 73,
+            "total": 409
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Delphox": {
+        "name": "Delphox",
+        "species": "Fox Pokemon",
+        "id": "655",
+        "type": [
+            "Fire",
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(39 kg)",
+        "abilities": [
+            "Blaze",
+            "Magician"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 69,
+            "defense": 72,
+            "sp.atk": 114,
+            "sp.def": 100,
+            "speed": 104,
+            "total": 534
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Froakie": {
+        "name": "Froakie",
+        "species": "Bubble Frog Pokemon",
+        "id": "656",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.3m)",
+        "weight": "(7 kg)",
+        "abilities": [
+            "Torrent",
+            "Protean"
+        ],
+        "stats": {
+            "hp": 41,
+            "attack": 56,
+            "defense": 40,
+            "sp.atk": 62,
+            "sp.def": 44,
+            "speed": 71,
+            "total": 314
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Frogadier": {
+        "name": "Frogadier",
+        "species": "Bubble Frog Pokemon",
+        "id": "657",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(10.9 kg)",
+        "abilities": [
+            "Torrent",
+            "Protean"
+        ],
+        "stats": {
+            "hp": 54,
+            "attack": 63,
+            "defense": 52,
+            "sp.atk": 83,
+            "sp.def": 56,
+            "speed": 97,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Greninja": {
+        "name": "Greninja",
+        "species": "Ninja Pokemon",
+        "id": "658",
+        "type": [
+            "Water",
+            "Dark"
+        ],
+        "height": "(1.5m)",
+        "weight": "(40 kg)",
+        "abilities": [
+            "Torrent",
+            "Protean",
+            "Battle Bond"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 145,
+            "defense": 67,
+            "sp.atk": 153,
+            "sp.def": 71,
+            "speed": 132,
+            "total": 640
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Bunnelby": {
+        "name": "Bunnelby",
+        "species": "Digging Pokemon",
+        "id": "659",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Pickup",
+            "Cheek Pouch",
+            "Huge Power"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 36,
+            "defense": 38,
+            "sp.atk": 32,
+            "sp.def": 36,
+            "speed": 57,
+            "total": 237
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Diggersby": {
+        "name": "Diggersby",
+        "species": "Digging Pokemon",
+        "id": "660",
+        "type": [
+            "Normal",
+            "Ground"
+        ],
+        "height": "(1m)",
+        "weight": "(42.4 kg)",
+        "abilities": [
+            "Pickup",
+            "Cheek Pouch",
+            "Huge Power"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 56,
+            "defense": 77,
+            "sp.atk": 50,
+            "sp.def": 77,
+            "speed": 78,
+            "total": 423
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Fletchling": {
+        "name": "Fletchling",
+        "species": "Tiny Robin Pokemon",
+        "id": "661",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.7 kg)",
+        "abilities": [
+            "Big Pecks",
+            "Gale Wings"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 50,
+            "defense": 43,
+            "sp.atk": 40,
+            "sp.def": 38,
+            "speed": 62,
+            "total": 278
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Fletchinder": {
+        "name": "Fletchinder",
+        "species": "Ember Pokemon",
+        "id": "662",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "(0.7m)",
+        "weight": "(16 kg)",
+        "abilities": [
+            "Flame Body",
+            "Gale Wings"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 73,
+            "defense": 55,
+            "sp.atk": 56,
+            "sp.def": 52,
+            "speed": 84,
+            "total": 382
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Talonflame": {
+        "name": "Talonflame",
+        "species": "Scorching Pokemon",
+        "id": "663",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(24.5 kg)",
+        "abilities": [
+            "Flame Body",
+            "Gale Wings"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 81,
+            "defense": 71,
+            "sp.atk": 74,
+            "sp.def": 69,
+            "speed": 126,
+            "total": 499
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Scatterbug": {
+        "name": "Scatterbug",
+        "species": "Scatterdust Pokemon",
+        "id": "664",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.5 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Compoundeyes",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 35,
+            "defense": 40,
+            "sp.atk": 27,
+            "sp.def": 25,
+            "speed": 35,
+            "total": 200
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Spewpa": {
+        "name": "Spewpa",
+        "species": "Scatterdust Pokemon",
+        "id": "665",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.3m)",
+        "weight": "(8.4 kg)",
+        "abilities": [
+            "Shed Skin",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 22,
+            "defense": 60,
+            "sp.atk": 27,
+            "sp.def": 30,
+            "speed": 29,
+            "total": 213
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Vivillon": {
+        "name": "Vivillon",
+        "species": "Scale Pokemon",
+        "id": "666",
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "height": "(1.2m)",
+        "weight": "(17 kg)",
+        "abilities": [
+            "Shield Dust",
+            "Compoundeyes",
+            "Friend Guard"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 52,
+            "defense": 50,
+            "sp.atk": 90,
+            "sp.def": 50,
+            "speed": 89,
+            "total": 411
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Litleo": {
+        "name": "Litleo",
+        "species": "Lion Cub Pokemon",
+        "id": "667",
+        "type": [
+            "Fire",
+            "Normal"
+        ],
+        "height": "(0.6m)",
+        "weight": "(13.5 kg)",
+        "abilities": [
+            "Rivalry",
+            "Unnerve",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 50,
+            "defense": 58,
+            "sp.atk": 73,
+            "sp.def": 54,
+            "speed": 72,
+            "total": 369
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Pyroar": {
+        "name": "Pyroar",
+        "species": "Royal Pokemon",
+        "id": "668",
+        "type": [
+            "Fire",
+            "Normal"
+        ],
+        "height": "(1.5m)",
+        "weight": "(81.5 kg)",
+        "abilities": [
+            "Rivalry",
+            "Unnerve",
+            "Moxie"
+        ],
+        "stats": {
+            "hp": 86,
+            "attack": 68,
+            "defense": 72,
+            "sp.atk": 109,
+            "sp.def": 66,
+            "speed": 106,
+            "total": 507
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Flabebe": {
+        "name": "Flabebe",
+        "species": "Single Bloom Pokemon",
+        "id": "669",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.1m)",
+        "weight": "(0.1 kg)",
+        "abilities": [
+            "Flower Veil",
+            "Symbiosis"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 38,
+            "defense": 39,
+            "sp.atk": 61,
+            "sp.def": 79,
+            "speed": 42,
+            "total": 303
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Floette": {
+        "name": "Floette",
+        "species": "Fairy Pokemon",
+        "id": "670",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.9 kg)",
+        "abilities": [
+            "Flower Veil",
+            "Symbiosis"
+        ],
+        "stats": {
+            "hp": 74,
+            "attack": 65,
+            "defense": 67,
+            "sp.atk": 125,
+            "sp.def": 128,
+            "speed": 92,
+            "total": 551
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Florges": {
+        "name": "Florges",
+        "species": "Garden Pokemon",
+        "id": "671",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(1.1m)",
+        "weight": "(10 kg)",
+        "abilities": [
+            "Flower Veil",
+            "Symbiosis"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 65,
+            "defense": 68,
+            "sp.atk": 112,
+            "sp.def": 154,
+            "speed": 75,
+            "total": 552
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Skiddo": {
+        "name": "Skiddo",
+        "species": "Mount Pokemon",
+        "id": "672",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.9m)",
+        "weight": "(31 kg)",
+        "abilities": [
+            "Sap Sipper",
+            "Grass Pelt"
+        ],
+        "stats": {
+            "hp": 66,
+            "attack": 65,
+            "defense": 48,
+            "sp.atk": 62,
+            "sp.def": 57,
+            "speed": 52,
+            "total": 350
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Gogoat": {
+        "name": "Gogoat",
+        "species": "Mount Pokemon",
+        "id": "673",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.7m)",
+        "weight": "(91 kg)",
+        "abilities": [
+            "Sap Sipper",
+            "Grass Pelt"
+        ],
+        "stats": {
+            "hp": 123,
+            "attack": 100,
+            "defense": 62,
+            "sp.atk": 97,
+            "sp.def": 81,
+            "speed": 68,
+            "total": 531
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Pancham": {
+        "name": "Pancham",
+        "species": "Playful Pokemon",
+        "id": "674",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8 kg)",
+        "abilities": [
+            "Iron Fist",
+            "Mold Breaker",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 67,
+            "attack": 82,
+            "defense": 62,
+            "sp.atk": 46,
+            "sp.def": 48,
+            "speed": 43,
+            "total": 348
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Pangoro": {
+        "name": "Pangoro",
+        "species": "Daunting Pokemon",
+        "id": "675",
+        "type": [
+            "Fighting",
+            "Dark"
+        ],
+        "height": "(2.1m)",
+        "weight": "(136 kg)",
+        "abilities": [
+            "Iron Fist",
+            "Mold Breaker",
+            "Scrappy"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 124,
+            "defense": 78,
+            "sp.atk": 69,
+            "sp.def": 71,
+            "speed": 58,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Furfrou": {
+        "name": "Furfrou",
+        "species": "Poodle Pokemon",
+        "id": "676",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.2m)",
+        "weight": "(28 kg)",
+        "abilities": [
+            "Fur Coat"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 80,
+            "defense": 60,
+            "sp.atk": 65,
+            "sp.def": 90,
+            "speed": 102,
+            "total": 472
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Espurr": {
+        "name": "Espurr",
+        "species": "Restraint Pokemon",
+        "id": "677",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Infiltrator",
+            "Own Tempo"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 48,
+            "defense": 54,
+            "sp.atk": 63,
+            "sp.def": 60,
+            "speed": 68,
+            "total": 355
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Meowstic": {
+        "name": "Meowstic",
+        "species": "Constraint Pokemon",
+        "id": "678",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.6m)",
+        "weight": "(8.5 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Infiltrator",
+            "Prankster",
+            "Competitive"
+        ],
+        "stats": {
+            "hp": 74,
+            "attack": 48,
+            "defense": 76,
+            "sp.atk": 83,
+            "sp.def": 81,
+            "speed": 104,
+            "total": 466
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Honedge": {
+        "name": "Honedge",
+        "species": "Sword Pokemon",
+        "id": "679",
+        "type": [
+            "Steel",
+            "Ghost"
+        ],
+        "height": "(0.8m)",
+        "weight": "(2 kg)",
+        "abilities": [
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 80,
+            "defense": 100,
+            "sp.atk": 35,
+            "sp.def": 37,
+            "speed": 28,
+            "total": 325
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Doublade": {
+        "name": "Doublade",
+        "species": "Sword Pokemon",
+        "id": "680",
+        "type": [
+            "Steel",
+            "Ghost"
+        ],
+        "height": "(0.8m)",
+        "weight": "(4.5 kg)",
+        "abilities": [
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 110,
+            "defense": 150,
+            "sp.atk": 45,
+            "sp.def": 49,
+            "speed": 35,
+            "total": 448
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Aegislash": {
+        "name": "Aegislash",
+        "species": "Royal Sword Pokemon",
+        "id": "681",
+        "type": [
+            "Steel",
+            "Ghost"
+        ],
+        "height": "(1.7m)",
+        "weight": "(53 kg)",
+        "abilities": [
+            "Stance Change"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 150,
+            "defense": 50,
+            "sp.atk": 150,
+            "sp.def": 50,
+            "speed": 60,
+            "total": 520
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Spritzee": {
+        "name": "Spritzee",
+        "species": "Perfume Pokemon",
+        "id": "682",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.5 kg)",
+        "abilities": [
+            "Healer",
+            "Aroma Veil"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 52,
+            "defense": 60,
+            "sp.atk": 63,
+            "sp.def": 65,
+            "speed": 23,
+            "total": 341
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Aromatisse": {
+        "name": "Aromatisse",
+        "species": "Fragrance Pokemon",
+        "id": "683",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.8m)",
+        "weight": "(15.5 kg)",
+        "abilities": [
+            "Healer",
+            "Aroma Veil"
+        ],
+        "stats": {
+            "hp": 101,
+            "attack": 72,
+            "defense": 72,
+            "sp.atk": 99,
+            "sp.def": 89,
+            "speed": 29,
+            "total": 462
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Swirlix": {
+        "name": "Swirlix",
+        "species": "Cotton Candy Pokemon",
+        "id": "684",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.4m)",
+        "weight": "(3.5 kg)",
+        "abilities": [
+            "Sweet Veil",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 48,
+            "defense": 66,
+            "sp.atk": 59,
+            "sp.def": 57,
+            "speed": 49,
+            "total": 341
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Slurpuff": {
+        "name": "Slurpuff",
+        "species": "Meringue Pokemon",
+        "id": "685",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.8m)",
+        "weight": "(5 kg)",
+        "abilities": [
+            "Sweet Veil",
+            "Unburden"
+        ],
+        "stats": {
+            "hp": 82,
+            "attack": 80,
+            "defense": 86,
+            "sp.atk": 85,
+            "sp.def": 75,
+            "speed": 72,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Inkay": {
+        "name": "Inkay",
+        "species": "Revolving Pokemon",
+        "id": "686",
+        "type": [
+            "Dark",
+            "Psychic"
+        ],
+        "height": "(0.4m)",
+        "weight": "(3.5 kg)",
+        "abilities": [
+            "Contrary",
+            "Suction Cups",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 53,
+            "attack": 54,
+            "defense": 53,
+            "sp.atk": 37,
+            "sp.def": 46,
+            "speed": 45,
+            "total": 288
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Malamar": {
+        "name": "Malamar",
+        "species": "Overturning Pokemon",
+        "id": "687",
+        "type": [
+            "Dark",
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(47 kg)",
+        "abilities": [
+            "Contrary",
+            "Suction Cups",
+            "Infiltrator"
+        ],
+        "stats": {
+            "hp": 86,
+            "attack": 92,
+            "defense": 88,
+            "sp.atk": 68,
+            "sp.def": 75,
+            "speed": 73,
+            "total": 482
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Binacle": {
+        "name": "Binacle",
+        "species": "Two-Handed Pokemon",
+        "id": "688",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(31 kg)",
+        "abilities": [
+            "Tough Claws",
+            "Sniper",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 42,
+            "attack": 52,
+            "defense": 67,
+            "sp.atk": 39,
+            "sp.def": 56,
+            "speed": 50,
+            "total": 306
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Barbaracle": {
+        "name": "Barbaracle",
+        "species": "Collective Pokemon",
+        "id": "689",
+        "type": [
+            "Rock",
+            "Water"
+        ],
+        "height": "(1.3m)",
+        "weight": "(96 kg)",
+        "abilities": [
+            "Tough Claws",
+            "Sniper",
+            "Pickpocket"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 105,
+            "defense": 115,
+            "sp.atk": 54,
+            "sp.def": 86,
+            "speed": 68,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Skrelp": {
+        "name": "Skrelp",
+        "species": "Mock Kelp Pokemon",
+        "id": "690",
+        "type": [
+            "Poison",
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(7.3 kg)",
+        "abilities": [
+            "Poison Point",
+            "Poison Touch",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 60,
+            "defense": 60,
+            "sp.atk": 60,
+            "sp.def": 60,
+            "speed": 30,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Dragalge": {
+        "name": "Dragalge",
+        "species": "Mock Kelp Pokemon",
+        "id": "691",
+        "type": [
+            "Poison",
+            "Dragon"
+        ],
+        "height": "(1.8m)",
+        "weight": "(81.5 kg)",
+        "abilities": [
+            "Poison Point",
+            "Poison Touch",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 75,
+            "defense": 90,
+            "sp.atk": 97,
+            "sp.def": 123,
+            "speed": 44,
+            "total": 494
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Clauncher": {
+        "name": "Clauncher",
+        "species": "Water Gun Pokemon",
+        "id": "692",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(8.3 kg)",
+        "abilities": [
+            "Mega Launcher"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 53,
+            "defense": 62,
+            "sp.atk": 58,
+            "sp.def": 63,
+            "speed": 44,
+            "total": 330
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Clawitzer": {
+        "name": "Clawitzer",
+        "species": "Howitzer Pokemon",
+        "id": "693",
+        "type": [
+            "Water"
+        ],
+        "height": "(1.3m)",
+        "weight": "(35.3 kg)",
+        "abilities": [
+            "Mega Launcher"
+        ],
+        "stats": {
+            "hp": 71,
+            "attack": 73,
+            "defense": 88,
+            "sp.atk": 120,
+            "sp.def": 89,
+            "speed": 59,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Helioptile": {
+        "name": "Helioptile",
+        "species": "Generator Pokemon",
+        "id": "694",
+        "type": [
+            "Electric",
+            "Normal"
+        ],
+        "height": "(0.5m)",
+        "weight": "(6 kg)",
+        "abilities": [
+            "Dry Skin",
+            "Sand Veil",
+            "Solar Power"
+        ],
+        "stats": {
+            "hp": 44,
+            "attack": 38,
+            "defense": 33,
+            "sp.atk": 61,
+            "sp.def": 43,
+            "speed": 70,
+            "total": 289
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Heliolisk": {
+        "name": "Heliolisk",
+        "species": "Generator Pokemon",
+        "id": "695",
+        "type": [
+            "Electric",
+            "Normal"
+        ],
+        "height": "(1m)",
+        "weight": "(21 kg)",
+        "abilities": [
+            "Dry Skin",
+            "Sand Veil",
+            "Solar Power"
+        ],
+        "stats": {
+            "hp": 62,
+            "attack": 55,
+            "defense": 52,
+            "sp.atk": 109,
+            "sp.def": 94,
+            "speed": 109,
+            "total": 481
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Tyrunt": {
+        "name": "Tyrunt",
+        "species": "Royal Heir Pokemon",
+        "id": "696",
+        "type": [
+            "Rock",
+            "Dragon"
+        ],
+        "height": "(0.8m)",
+        "weight": "(26 kg)",
+        "abilities": [
+            "Strong Jaw",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 58,
+            "attack": 89,
+            "defense": 77,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 48,
+            "total": 362
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Tyrantrum": {
+        "name": "Tyrantrum",
+        "species": "Despot Pokemon",
+        "id": "697",
+        "type": [
+            "Rock",
+            "Dragon"
+        ],
+        "height": "(2.5m)",
+        "weight": "(270 kg)",
+        "abilities": [
+            "Strong Jaw",
+            "Rock Head"
+        ],
+        "stats": {
+            "hp": 82,
+            "attack": 121,
+            "defense": 119,
+            "sp.atk": 69,
+            "sp.def": 59,
+            "speed": 71,
+            "total": 521
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Amaura": {
+        "name": "Amaura",
+        "species": "Tundra Pokemon",
+        "id": "698",
+        "type": [
+            "Rock",
+            "Ice"
+        ],
+        "height": "(1.3m)",
+        "weight": "(25.2 kg)",
+        "abilities": [
+            "Refrigerate",
+            "Snow Warning"
+        ],
+        "stats": {
+            "hp": 77,
+            "attack": 59,
+            "defense": 50,
+            "sp.atk": 67,
+            "sp.def": 63,
+            "speed": 46,
+            "total": 362
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Aurorus": {
+        "name": "Aurorus",
+        "species": "Tundra Pokemon",
+        "id": "699",
+        "type": [
+            "Rock",
+            "Ice"
+        ],
+        "height": "(2.7m)",
+        "weight": "(225 kg)",
+        "abilities": [
+            "Refrigerate",
+            "Snow Warning"
+        ],
+        "stats": {
+            "hp": 123,
+            "attack": 77,
+            "defense": 72,
+            "sp.atk": 99,
+            "sp.def": 92,
+            "speed": 58,
+            "total": 521
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Sylveon": {
+        "name": "Sylveon",
+        "species": "Intertwining Pokemon",
+        "id": "700",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(1m)",
+        "weight": "(23.5 kg)",
+        "abilities": [
+            "Cute Charm",
+            "Pixilate"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 65,
+            "defense": 65,
+            "sp.atk": 110,
+            "sp.def": 130,
+            "speed": 60,
+            "total": 525
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Hawlucha": {
+        "name": "Hawlucha",
+        "species": "Wrestling Pokemon",
+        "id": "701",
+        "type": [
+            "Fighting",
+            "Flying"
+        ],
+        "height": "(0.8m)",
+        "weight": "(21.5 kg)",
+        "abilities": [
+            "Limber",
+            "Unburden",
+            "Mold Breaker"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 92,
+            "defense": 75,
+            "sp.atk": 74,
+            "sp.def": 63,
+            "speed": 118,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Dedenne": {
+        "name": "Dedenne",
+        "species": "Antenna Pokemon",
+        "id": "702",
+        "type": [
+            "Electric",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(2.2 kg)",
+        "abilities": [
+            "Cheek Pouch",
+            "Pickup",
+            "Plus"
+        ],
+        "stats": {
+            "hp": 67,
+            "attack": 58,
+            "defense": 57,
+            "sp.atk": 81,
+            "sp.def": 67,
+            "speed": 101,
+            "total": 431
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Carbink": {
+        "name": "Carbink",
+        "species": "Jewel Pokemon",
+        "id": "703",
+        "type": [
+            "Rock",
+            "Fairy"
+        ],
+        "height": "(0.3m)",
+        "weight": "(5.7 kg)",
+        "abilities": [
+            "Clear Body",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 50,
+            "defense": 150,
+            "sp.atk": 50,
+            "sp.def": 150,
+            "speed": 50,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Goomy": {
+        "name": "Goomy",
+        "species": "Soft Tissue Pokemon",
+        "id": "704",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(0.3m)",
+        "weight": "(2.8 kg)",
+        "abilities": [
+            "Sap Sipper",
+            "Hydration",
+            "Gooey"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 50,
+            "defense": 35,
+            "sp.atk": 55,
+            "sp.def": 75,
+            "speed": 40,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Sliggoo": {
+        "name": "Sliggoo",
+        "species": "Soft Tissue Pokemon",
+        "id": "705",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(0.8m)",
+        "weight": "(17.5 kg)",
+        "abilities": [
+            "Sap Sipper",
+            "Hydration",
+            "Gooey"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 75,
+            "defense": 53,
+            "sp.atk": 83,
+            "sp.def": 113,
+            "speed": 60,
+            "total": 452
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Goodra": {
+        "name": "Goodra",
+        "species": "Dragon Pokemon",
+        "id": "706",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(2m)",
+        "weight": "(150.5 kg)",
+        "abilities": [
+            "Sap Sipper",
+            "Hydration",
+            "Gooey"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 100,
+            "defense": 70,
+            "sp.atk": 110,
+            "sp.def": 150,
+            "speed": 80,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Klefki": {
+        "name": "Klefki",
+        "species": "Key Ring Pokemon",
+        "id": "707",
+        "type": [
+            "Steel",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(3 kg)",
+        "abilities": [
+            "Prankster",
+            "Magician"
+        ],
+        "stats": {
+            "hp": 57,
+            "attack": 80,
+            "defense": 91,
+            "sp.atk": 80,
+            "sp.def": 87,
+            "speed": 75,
+            "total": 470
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Phantump": {
+        "name": "Phantump",
+        "species": "Stump Pokemon",
+        "id": "708",
+        "type": [
+            "Ghost",
+            "Grass"
+        ],
+        "height": "(0.4m)",
+        "weight": "(7 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Frisk",
+            "Harvest"
+        ],
+        "stats": {
+            "hp": 43,
+            "attack": 70,
+            "defense": 48,
+            "sp.atk": 50,
+            "sp.def": 60,
+            "speed": 38,
+            "total": 309
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Trevenant": {
+        "name": "Trevenant",
+        "species": "Elder Tree Pokemon",
+        "id": "709",
+        "type": [
+            "Ghost",
+            "Grass"
+        ],
+        "height": "(1.5m)",
+        "weight": "(71 kg)",
+        "abilities": [
+            "Natural Cure",
+            "Frisk",
+            "Harvest"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 110,
+            "defense": 76,
+            "sp.atk": 65,
+            "sp.def": 82,
+            "speed": 56,
+            "total": 474
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Pumpkaboo": {
+        "name": "Pumpkaboo",
+        "species": "Pumpkin Pokemon",
+        "id": "710",
+        "type": [
+            "Ghost",
+            "Grass"
+        ],
+        "height": "(0.8m)",
+        "weight": "(15 kg)",
+        "abilities": [
+            "Pickup",
+            "Frisk",
+            "Insomnia"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 66,
+            "defense": 70,
+            "sp.atk": 44,
+            "sp.def": 55,
+            "speed": 41,
+            "total": 335
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Gourgeist": {
+        "name": "Gourgeist",
+        "species": "Pumpkin Pokemon",
+        "id": "711",
+        "type": [
+            "Ghost",
+            "Grass"
+        ],
+        "height": "(1.7m)",
+        "weight": "(39 kg)",
+        "abilities": [
+            "Pickup",
+            "Frisk",
+            "Insomnia"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 100,
+            "defense": 122,
+            "sp.atk": 58,
+            "sp.def": 75,
+            "speed": 54,
+            "total": 494
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Bergmite": {
+        "name": "Bergmite",
+        "species": "Ice Chunk Pokemon",
+        "id": "712",
+        "type": [
+            "Ice"
+        ],
+        "height": "(1m)",
+        "weight": "(99.5 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Ice Body",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 69,
+            "defense": 85,
+            "sp.atk": 32,
+            "sp.def": 35,
+            "speed": 28,
+            "total": 304
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Avalugg": {
+        "name": "Avalugg",
+        "species": "Iceberg Pokemon",
+        "id": "713",
+        "type": [
+            "Ice"
+        ],
+        "height": "(2m)",
+        "weight": "(505 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Ice Body",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 117,
+            "defense": 184,
+            "sp.atk": 44,
+            "sp.def": 46,
+            "speed": 28,
+            "total": 514
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Noibat": {
+        "name": "Noibat",
+        "species": "Sound Wave Pokemon",
+        "id": "714",
+        "type": [
+            "Flying",
+            "Dragon"
+        ],
+        "height": "(0.5m)",
+        "weight": "(8 kg)",
+        "abilities": [
+            "Frisk",
+            "Infiltrator",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 30,
+            "defense": 35,
+            "sp.atk": 45,
+            "sp.def": 40,
+            "speed": 55,
+            "total": 245
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Noivern": {
+        "name": "Noivern",
+        "species": "Sound Wave Pokemon",
+        "id": "715",
+        "type": [
+            "Flying",
+            "Dragon"
+        ],
+        "height": "(1.5m)",
+        "weight": "(85 kg)",
+        "abilities": [
+            "Frisk",
+            "Infiltrator",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 70,
+            "defense": 80,
+            "sp.atk": 97,
+            "sp.def": 80,
+            "speed": 123,
+            "total": 535
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Xerneas": {
+        "name": "Xerneas",
+        "species": "Life Pokemon",
+        "id": "716",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(3m)",
+        "weight": "(215 kg)",
+        "abilities": [
+            "Fairy Aura"
+        ],
+        "stats": {
+            "hp": 126,
+            "attack": 131,
+            "defense": 95,
+            "sp.atk": 131,
+            "sp.def": 98,
+            "speed": 99,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Yveltal": {
+        "name": "Yveltal",
+        "species": "Destruction Pokemon",
+        "id": "717",
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "height": "(5.8m)",
+        "weight": "(203 kg)",
+        "abilities": [
+            "Dark Aura"
+        ],
+        "stats": {
+            "hp": 126,
+            "attack": 131,
+            "defense": 95,
+            "sp.atk": 131,
+            "sp.def": 98,
+            "speed": 99,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Zygarde": {
+        "name": "Zygarde",
+        "species": "Order Pokemon",
+        "id": "718",
+        "type": [
+            "Dragon",
+            "Ground"
+        ],
+        "height": "(5m)",
+        "weight": "(284.6 kg)",
+        "abilities": [
+            "Aura Break",
+            "Power Construct"
+        ],
+        "stats": {
+            "hp": 216,
+            "attack": 100,
+            "defense": 121,
+            "sp.atk": 91,
+            "sp.def": 95,
+            "speed": 85,
+            "total": 708
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Diancie": {
+        "name": "Diancie",
+        "species": "Jewel Pokemon",
+        "id": "719",
+        "type": [
+            "Rock",
+            "Fairy"
+        ],
+        "height": "(0.7m)",
+        "weight": "(8.8 kg)",
+        "abilities": [
+            "Clear Body"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 160,
+            "defense": 110,
+            "sp.atk": 160,
+            "sp.def": 110,
+            "speed": 110,
+            "total": 700
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Hoopa": {
+        "name": "Hoopa",
+        "species": "Mischief Pokemon (Confined)Djinn Pokemonn (Unbound)",
+        "id": "720",
+        "type": [
+            "Psychic",
+            "Ghost"
+        ],
+        "height": "(Nonem)",
+        "weight": "(None kg)",
+        "abilities": [
+            "Magician"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 160,
+            "defense": 60,
+            "sp.atk": 170,
+            "sp.def": 130,
+            "speed": 80,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Volcanion": {
+        "name": "Volcanion",
+        "species": "Steam Pokemon",
+        "id": "721",
+        "type": [
+            "Fire",
+            "Water"
+        ],
+        "height": "(1.7m)",
+        "weight": "(195 kg)",
+        "abilities": [
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 110,
+            "defense": 120,
+            "sp.atk": 130,
+            "sp.def": 90,
+            "speed": 70,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 6
+    },
+    "Rowlet": {
+        "name": "Rowlet",
+        "species": "Grass Quill Pokemon",
+        "id": "722",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.5 kg)",
+        "abilities": [
+            "Overgrow",
+            "Long Reach"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 55,
+            "defense": 55,
+            "sp.atk": 50,
+            "sp.def": 50,
+            "speed": 42,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Dartrix": {
+        "name": "Dartrix",
+        "species": "Blade Quill Pokemon",
+        "id": "723",
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "height": "(0.7m)",
+        "weight": "(16 kg)",
+        "abilities": [
+            "Overgrow",
+            "Long Reach"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 75,
+            "defense": 75,
+            "sp.atk": 70,
+            "sp.def": 70,
+            "speed": 52,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Decidueye": {
+        "name": "Decidueye",
+        "species": "Arrow Quill Pokemon",
+        "id": "724",
+        "type": [
+            "Grass",
+            "Ghost"
+        ],
+        "height": "(1.6m)",
+        "weight": "(36.6 kg)",
+        "abilities": [
+            "Overgrow",
+            "Long Reach"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 107,
+            "defense": 75,
+            "sp.atk": 100,
+            "sp.def": 100,
+            "speed": 70,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Litten": {
+        "name": "Litten",
+        "species": "Fire Cat Pokemon",
+        "id": "725",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.3 kg)",
+        "abilities": [
+            "Blaze",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 65,
+            "defense": 40,
+            "sp.atk": 60,
+            "sp.def": 40,
+            "speed": 70,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Torracat": {
+        "name": "Torracat",
+        "species": "Fire Cat Pokemon",
+        "id": "726",
+        "type": [
+            "Fire"
+        ],
+        "height": "(0.7m)",
+        "weight": "(25 kg)",
+        "abilities": [
+            "Blaze",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 85,
+            "defense": 50,
+            "sp.atk": 80,
+            "sp.def": 50,
+            "speed": 90,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Incineroar": {
+        "name": "Incineroar",
+        "species": "Heel Pokemon",
+        "id": "727",
+        "type": [
+            "Fire",
+            "Dark"
+        ],
+        "height": "(1.8m)",
+        "weight": "(83 kg)",
+        "abilities": [
+            "Blaze",
+            "Intimidate"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 115,
+            "defense": 90,
+            "sp.atk": 80,
+            "sp.def": 90,
+            "speed": 60,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Popplio": {
+        "name": "Popplio",
+        "species": "Sea Lion Pokemon",
+        "id": "728",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(7.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Liquid Voice"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 54,
+            "defense": 54,
+            "sp.atk": 66,
+            "sp.def": 56,
+            "speed": 40,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Brionne": {
+        "name": "Brionne",
+        "species": "Pop Star Pokemon",
+        "id": "729",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.6m)",
+        "weight": "(17.5 kg)",
+        "abilities": [
+            "Torrent",
+            "Liquid Voice"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 69,
+            "defense": 69,
+            "sp.atk": 91,
+            "sp.def": 81,
+            "speed": 50,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Primarina": {
+        "name": "Primarina",
+        "species": "Soloist Pokemon",
+        "id": "730",
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "height": "(1.8m)",
+        "weight": "(44 kg)",
+        "abilities": [
+            "Torrent",
+            "Liquid Voice"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 74,
+            "defense": 74,
+            "sp.atk": 126,
+            "sp.def": 116,
+            "speed": 60,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Pikipek": {
+        "name": "Pikipek",
+        "species": "Woodpecker Pokemon",
+        "id": "731",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Skill Link",
+            "Pickup"
+        ],
+        "stats": {
+            "hp": 35,
+            "attack": 75,
+            "defense": 30,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 65,
+            "total": 265
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Trumbeak": {
+        "name": "Trumbeak",
+        "species": "Bugle Beak Pokemon",
+        "id": "732",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(14.8 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Skill Link",
+            "Pickup"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 85,
+            "defense": 50,
+            "sp.atk": 40,
+            "sp.def": 50,
+            "speed": 75,
+            "total": 355
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Toucannon": {
+        "name": "Toucannon",
+        "species": "Cannon Pokemon",
+        "id": "733",
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "height": "(1.1m)",
+        "weight": "(26 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Skill Link",
+            "Sheer Force"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 120,
+            "defense": 75,
+            "sp.atk": 75,
+            "sp.def": 75,
+            "speed": 60,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Yungoos": {
+        "name": "Yungoos",
+        "species": "Loitering Pokemon",
+        "id": "734",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(6 kg)",
+        "abilities": [
+            "Stakeout",
+            "Strong Jaw",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 48,
+            "attack": 70,
+            "defense": 30,
+            "sp.atk": 30,
+            "sp.def": 30,
+            "speed": 45,
+            "total": 253
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Gumshoos": {
+        "name": "Gumshoos",
+        "species": "Stakeout Pokemon",
+        "id": "735",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.7m)",
+        "weight": "(14.2 kg)",
+        "abilities": [
+            "Stakeout",
+            "Strong Jaw",
+            "Adaptability"
+        ],
+        "stats": {
+            "hp": 88,
+            "attack": 110,
+            "defense": 60,
+            "sp.atk": 55,
+            "sp.def": 60,
+            "speed": 45,
+            "total": 418
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Grubbin": {
+        "name": "Grubbin",
+        "species": "Larva Pokemon",
+        "id": "736",
+        "type": [
+            "Bug"
+        ],
+        "height": "(0.4m)",
+        "weight": "(4.4 kg)",
+        "abilities": [
+            "Swarm"
+        ],
+        "stats": {
+            "hp": 47,
+            "attack": 62,
+            "defense": 45,
+            "sp.atk": 55,
+            "sp.def": 45,
+            "speed": 46,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Charjabug": {
+        "name": "Charjabug",
+        "species": "Battery Pokemon",
+        "id": "737",
+        "type": [
+            "Bug",
+            "Electric"
+        ],
+        "height": "(0.5m)",
+        "weight": "(10.5 kg)",
+        "abilities": [
+            "Battery"
+        ],
+        "stats": {
+            "hp": 57,
+            "attack": 82,
+            "defense": 95,
+            "sp.atk": 55,
+            "sp.def": 75,
+            "speed": 36,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Vikavolt": {
+        "name": "Vikavolt",
+        "species": "Stag Beetle Pokemon",
+        "id": "738",
+        "type": [
+            "Bug",
+            "Electric"
+        ],
+        "height": "(1.5m)",
+        "weight": "(45 kg)",
+        "abilities": [
+            "Levitate"
+        ],
+        "stats": {
+            "hp": 77,
+            "attack": 70,
+            "defense": 90,
+            "sp.atk": 145,
+            "sp.def": 75,
+            "speed": 43,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Crabrawler": {
+        "name": "Crabrawler",
+        "species": "Boxing Pokemon",
+        "id": "739",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(0.6m)",
+        "weight": "(7 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Iron Fist",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 47,
+            "attack": 82,
+            "defense": 57,
+            "sp.atk": 42,
+            "sp.def": 47,
+            "speed": 63,
+            "total": 338
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Crabominable": {
+        "name": "Crabominable",
+        "species": "Woolly Crab Pokemon",
+        "id": "740",
+        "type": [
+            "Fighting",
+            "Ice"
+        ],
+        "height": "(1.7m)",
+        "weight": "(180 kg)",
+        "abilities": [
+            "Hyper Cutter",
+            "Iron Fist",
+            "Anger Point"
+        ],
+        "stats": {
+            "hp": 97,
+            "attack": 132,
+            "defense": 77,
+            "sp.atk": 62,
+            "sp.def": 67,
+            "speed": 43,
+            "total": 478
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Oricorio": {
+        "name": "Oricorio",
+        "species": "Dancing Pokemon",
+        "id": "741",
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "height": "(0.6m)",
+        "weight": "(3.4 kg)",
+        "abilities": [
+            "Dancer"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 70,
+            "defense": 70,
+            "sp.atk": 98,
+            "sp.def": 70,
+            "speed": 93,
+            "total": 476
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Cutiefly": {
+        "name": "Cutiefly",
+        "species": "Bee Fly Pokemon",
+        "id": "742",
+        "type": [
+            "Bug",
+            "Fairy"
+        ],
+        "height": "(0.1m)",
+        "weight": "(0.2 kg)",
+        "abilities": [
+            "Honey Gather",
+            "Shield Dust",
+            "Sweet Veil"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 45,
+            "defense": 40,
+            "sp.atk": 55,
+            "sp.def": 40,
+            "speed": 84,
+            "total": 304
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Ribombee": {
+        "name": "Ribombee",
+        "species": "Bee Fly Pokemon",
+        "id": "743",
+        "type": [
+            "Bug",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.5 kg)",
+        "abilities": [
+            "Honey Gather",
+            "Shield Dust",
+            "Sweet Veil"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 55,
+            "defense": 60,
+            "sp.atk": 95,
+            "sp.def": 70,
+            "speed": 124,
+            "total": 464
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Rockruff": {
+        "name": "Rockruff",
+        "species": "Puppy Pokemon",
+        "id": "744",
+        "type": [
+            "Rock"
+        ],
+        "height": "(0.5m)",
+        "weight": "(9.2 kg)",
+        "abilities": [
+            "Keen Eye",
+            "Vital Spirit",
+            "Steadfast"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 65,
+            "defense": 40,
+            "sp.atk": 30,
+            "sp.def": 40,
+            "speed": 60,
+            "total": 280
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Lycanroc": {
+        "name": "Lycanroc",
+        "species": "Wolf Pokemon",
+        "id": "745",
+        "type": [
+            "Rock"
+        ],
+        "height": "(Nonem)",
+        "weight": "(None kg)",
+        "abilities": [
+            "Keen Eye",
+            "Sand Rush",
+            "Steadfast",
+            "Keen Eye",
+            "Vital Spirit",
+            "No Guard"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 115,
+            "defense": 75,
+            "sp.atk": 55,
+            "sp.def": 75,
+            "speed": 82,
+            "total": 487
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Wishiwashi": {
+        "name": "Wishiwashi",
+        "species": "Small Fry Pokemon",
+        "id": "746",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Schooling"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 140,
+            "defense": 130,
+            "sp.atk": 140,
+            "sp.def": 135,
+            "speed": 30,
+            "total": 620
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Mareanie": {
+        "name": "Mareanie",
+        "species": "Brutal Star Pokemon",
+        "id": "747",
+        "type": [
+            "Poison",
+            "Water"
+        ],
+        "height": "(0.4m)",
+        "weight": "(8 kg)",
+        "abilities": [
+            "Merciless",
+            "Limber",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 53,
+            "defense": 62,
+            "sp.atk": 43,
+            "sp.def": 52,
+            "speed": 45,
+            "total": 305
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Toxapex": {
+        "name": "Toxapex",
+        "species": "Brutal Star Pokemon",
+        "id": "748",
+        "type": [
+            "Poison",
+            "Water"
+        ],
+        "height": "(0.7m)",
+        "weight": "(14.5 kg)",
+        "abilities": [
+            "Merciless",
+            "Limber",
+            "Regenerator"
+        ],
+        "stats": {
+            "hp": 50,
+            "attack": 63,
+            "defense": 152,
+            "sp.atk": 53,
+            "sp.def": 142,
+            "speed": 35,
+            "total": 495
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Mudbray": {
+        "name": "Mudbray",
+        "species": "Donkey Pokemon",
+        "id": "749",
+        "type": [
+            "Ground"
+        ],
+        "height": "(1m)",
+        "weight": "(110 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Stamina",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 100,
+            "defense": 70,
+            "sp.atk": 45,
+            "sp.def": 55,
+            "speed": 45,
+            "total": 385
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Mudsdale": {
+        "name": "Mudsdale",
+        "species": "Draft Horse Pokemon",
+        "id": "750",
+        "type": [
+            "Ground"
+        ],
+        "height": "(2.5m)",
+        "weight": "(920 kg)",
+        "abilities": [
+            "Own Tempo",
+            "Stamina",
+            "Inner Focus"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 125,
+            "defense": 100,
+            "sp.atk": 55,
+            "sp.def": 85,
+            "speed": 35,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Dewpider": {
+        "name": "Dewpider",
+        "species": "Water Bubble Pokemon",
+        "id": "751",
+        "type": [
+            "Water",
+            "Bug"
+        ],
+        "height": "(0.3m)",
+        "weight": "(4 kg)",
+        "abilities": [
+            "Water Bubble",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 38,
+            "attack": 40,
+            "defense": 52,
+            "sp.atk": 40,
+            "sp.def": 72,
+            "speed": 27,
+            "total": 269
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Araquanid": {
+        "name": "Araquanid",
+        "species": "Water Bubble Pokemon",
+        "id": "752",
+        "type": [
+            "Water",
+            "Bug"
+        ],
+        "height": "(1.8m)",
+        "weight": "(82 kg)",
+        "abilities": [
+            "Water Bubble",
+            "Water Absorb"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 70,
+            "defense": 92,
+            "sp.atk": 50,
+            "sp.def": 132,
+            "speed": 42,
+            "total": 454
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Fomantis": {
+        "name": "Fomantis",
+        "species": "Sickle Grass Pokemon",
+        "id": "753",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.5 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 55,
+            "defense": 35,
+            "sp.atk": 50,
+            "sp.def": 35,
+            "speed": 35,
+            "total": 250
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Lurantis": {
+        "name": "Lurantis",
+        "species": "Bloom Sickle Pokemon",
+        "id": "754",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.9m)",
+        "weight": "(18.5 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Contrary"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 105,
+            "defense": 90,
+            "sp.atk": 80,
+            "sp.def": 90,
+            "speed": 45,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Morelull": {
+        "name": "Morelull",
+        "species": "Illuminating Pokemon",
+        "id": "755",
+        "type": [
+            "Grass",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(1.5 kg)",
+        "abilities": [
+            "Illuminate",
+            "Effect Spore",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 40,
+            "attack": 35,
+            "defense": 55,
+            "sp.atk": 65,
+            "sp.def": 75,
+            "speed": 15,
+            "total": 285
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Shiinotic": {
+        "name": "Shiinotic",
+        "species": "Illuminating Pokemon",
+        "id": "756",
+        "type": [
+            "Grass",
+            "Fairy"
+        ],
+        "height": "(1m)",
+        "weight": "(11.5 kg)",
+        "abilities": [
+            "Illuminate",
+            "Effect Spore",
+            "Rain Dish"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 45,
+            "defense": 80,
+            "sp.atk": 90,
+            "sp.def": 100,
+            "speed": 30,
+            "total": 405
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Salandit": {
+        "name": "Salandit",
+        "species": "Toxic Lizard Pokemon",
+        "id": "757",
+        "type": [
+            "Poison",
+            "Fire"
+        ],
+        "height": "(0.6m)",
+        "weight": "(4.8 kg)",
+        "abilities": [
+            "Corrosion",
+            "Oblivious"
+        ],
+        "stats": {
+            "hp": 48,
+            "attack": 44,
+            "defense": 40,
+            "sp.atk": 71,
+            "sp.def": 40,
+            "speed": 77,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Salazzle": {
+        "name": "Salazzle",
+        "species": "Toxic Lizard Pokemon",
+        "id": "758",
+        "type": [
+            "Poison",
+            "Fire"
+        ],
+        "height": "(1.2m)",
+        "weight": "(22.2 kg)",
+        "abilities": [
+            "Corrosion",
+            "Oblivious"
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 64,
+            "defense": 60,
+            "sp.atk": 111,
+            "sp.def": 60,
+            "speed": 117,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Stufful": {
+        "name": "Stufful",
+        "species": "Flailing Pokemon",
+        "id": "759",
+        "type": [
+            "Normal",
+            "Fighting"
+        ],
+        "height": "(0.5m)",
+        "weight": "(6.8 kg)",
+        "abilities": [
+            "Fluffy",
+            "Klutz",
+            "Cute Charm"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 75,
+            "defense": 50,
+            "sp.atk": 45,
+            "sp.def": 50,
+            "speed": 50,
+            "total": 340
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Bewear": {
+        "name": "Bewear",
+        "species": "Strong Arm Pokemon",
+        "id": "760",
+        "type": [
+            "Normal",
+            "Fighting"
+        ],
+        "height": "(2.1m)",
+        "weight": "(135 kg)",
+        "abilities": [
+            "Fluffy",
+            "Klutz",
+            "Unnerve"
+        ],
+        "stats": {
+            "hp": 120,
+            "attack": 125,
+            "defense": 80,
+            "sp.atk": 55,
+            "sp.def": 60,
+            "speed": 60,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Bounsweet": {
+        "name": "Bounsweet",
+        "species": "Fruit Pokemon",
+        "id": "761",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3.2 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Oblivious",
+            "Sweet Veil"
+        ],
+        "stats": {
+            "hp": 42,
+            "attack": 30,
+            "defense": 38,
+            "sp.atk": 30,
+            "sp.def": 38,
+            "speed": 32,
+            "total": 210
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Steenee": {
+        "name": "Steenee",
+        "species": "Fruit Pokemon",
+        "id": "762",
+        "type": [
+            "Grass"
+        ],
+        "height": "(0.7m)",
+        "weight": "(8.2 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Oblivious",
+            "Sweet Veil"
+        ],
+        "stats": {
+            "hp": 52,
+            "attack": 40,
+            "defense": 48,
+            "sp.atk": 40,
+            "sp.def": 48,
+            "speed": 62,
+            "total": 290
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Tsareena": {
+        "name": "Tsareena",
+        "species": "Fruit Pokemon",
+        "id": "763",
+        "type": [
+            "Grass"
+        ],
+        "height": "(1.2m)",
+        "weight": "(21.4 kg)",
+        "abilities": [
+            "Leaf Guard",
+            "Queenly Majesty",
+            "Sweet Veil"
+        ],
+        "stats": {
+            "hp": 72,
+            "attack": 120,
+            "defense": 98,
+            "sp.atk": 50,
+            "sp.def": 98,
+            "speed": 72,
+            "total": 510
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Comfey": {
+        "name": "Comfey",
+        "species": "Posy Picker Pokemon",
+        "id": "764",
+        "type": [
+            "Fairy"
+        ],
+        "height": "(0.1m)",
+        "weight": "(0.3 kg)",
+        "abilities": [
+            "Flower Veil",
+            "Triage",
+            "Natural Cure"
+        ],
+        "stats": {
+            "hp": 51,
+            "attack": 52,
+            "defense": 90,
+            "sp.atk": 82,
+            "sp.def": 110,
+            "speed": 100,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Oranguru": {
+        "name": "Oranguru",
+        "species": "Sage Pokemon",
+        "id": "765",
+        "type": [
+            "Normal",
+            "Psychic"
+        ],
+        "height": "(1.5m)",
+        "weight": "(76 kg)",
+        "abilities": [
+            "Inner Focus",
+            "Telepathy",
+            "Symbiosis"
+        ],
+        "stats": {
+            "hp": 90,
+            "attack": 60,
+            "defense": 80,
+            "sp.atk": 90,
+            "sp.def": 110,
+            "speed": 60,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Passimian": {
+        "name": "Passimian",
+        "species": "Teamwork Pokemon",
+        "id": "766",
+        "type": [
+            "Fighting"
+        ],
+        "height": "(2m)",
+        "weight": "(82.8 kg)",
+        "abilities": [
+            "Receiver",
+            "Defiant"
+        ],
+        "stats": {
+            "hp": 100,
+            "attack": 120,
+            "defense": 90,
+            "sp.atk": 40,
+            "sp.def": 60,
+            "speed": 80,
+            "total": 490
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Wimpod": {
+        "name": "Wimpod",
+        "species": "Turn Tail Pokemon",
+        "id": "767",
+        "type": [
+            "Bug",
+            "Water"
+        ],
+        "height": "(0.5m)",
+        "weight": "(12 kg)",
+        "abilities": [
+            "Wimp Out"
+        ],
+        "stats": {
+            "hp": 25,
+            "attack": 35,
+            "defense": 40,
+            "sp.atk": 20,
+            "sp.def": 30,
+            "speed": 80,
+            "total": 230
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Golisopod": {
+        "name": "Golisopod",
+        "species": "Hard Scale Pokemon",
+        "id": "768",
+        "type": [
+            "Bug",
+            "Water"
+        ],
+        "height": "(2m)",
+        "weight": "(108 kg)",
+        "abilities": [
+            "Emergency Exit"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 125,
+            "defense": 140,
+            "sp.atk": 60,
+            "sp.def": 90,
+            "speed": 40,
+            "total": 530
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Sandygast": {
+        "name": "Sandygast",
+        "species": "Sand Heap Pokemon",
+        "id": "769",
+        "type": [
+            "Ghost",
+            "Ground"
+        ],
+        "height": "(0.5m)",
+        "weight": "(70 kg)",
+        "abilities": [
+            "Water Compaction",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 55,
+            "defense": 80,
+            "sp.atk": 70,
+            "sp.def": 45,
+            "speed": 15,
+            "total": 320
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Palossand": {
+        "name": "Palossand",
+        "species": "Sand Castle Pokemon",
+        "id": "770",
+        "type": [
+            "Ghost",
+            "Ground"
+        ],
+        "height": "(1.3m)",
+        "weight": "(250 kg)",
+        "abilities": [
+            "Water Compaction",
+            "Sand Veil"
+        ],
+        "stats": {
+            "hp": 85,
+            "attack": 75,
+            "defense": 110,
+            "sp.atk": 100,
+            "sp.def": 75,
+            "speed": 35,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Pyukumuku": {
+        "name": "Pyukumuku",
+        "species": "Sea Cucumber Pokemon",
+        "id": "771",
+        "type": [
+            "Water"
+        ],
+        "height": "(0.3m)",
+        "weight": "(1.2 kg)",
+        "abilities": [
+            "Innards Out",
+            "Unaware"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 60,
+            "defense": 130,
+            "sp.atk": 30,
+            "sp.def": 130,
+            "speed": 5,
+            "total": 410
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Type: Null": {
+        "name": "Type: Null",
+        "species": "Synthetic Pokemon",
+        "id": "772",
+        "type": [
+            "Normal"
+        ],
+        "height": "(1.9m)",
+        "weight": "(120.5 kg)",
+        "abilities": [
+            "Battle Armor"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 95,
+            "defense": 95,
+            "sp.atk": 95,
+            "sp.def": 95,
+            "speed": 59,
+            "total": 534
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Silvally": {
+        "name": "Silvally",
+        "species": "Synthetic Pokemon",
+        "id": "773",
+        "type": [
+            "Normal"
+        ],
+        "height": "(2.3m)",
+        "weight": "(100.5 kg)",
+        "abilities": [
+            "RKS System"
+        ],
+        "stats": {
+            "hp": 95,
+            "attack": 95,
+            "defense": 95,
+            "sp.atk": 95,
+            "sp.def": 95,
+            "speed": 95,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Minior": {
+        "name": "Minior",
+        "species": "Meteor Pokemon",
+        "id": "774",
+        "type": [
+            "Rock",
+            "Flying"
+        ],
+        "height": "(0.3m)",
+        "weight": "(40 kg)",
+        "abilities": [
+            "Shields Down"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 100,
+            "defense": 60,
+            "sp.atk": 100,
+            "sp.def": 60,
+            "speed": 120,
+            "total": 500
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Komala": {
+        "name": "Komala",
+        "species": "Drowsing Pokemon",
+        "id": "775",
+        "type": [
+            "Normal"
+        ],
+        "height": "(0.4m)",
+        "weight": "(19.9 kg)",
+        "abilities": [
+            "Comatose"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 115,
+            "defense": 65,
+            "sp.atk": 75,
+            "sp.def": 95,
+            "speed": 65,
+            "total": 480
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Turtonator": {
+        "name": "Turtonator",
+        "species": "Blast Turtle Pokemon",
+        "id": "776",
+        "type": [
+            "Fire",
+            "Dragon"
+        ],
+        "height": "(2m)",
+        "weight": "(212 kg)",
+        "abilities": [
+            "Shell Armor"
+        ],
+        "stats": {
+            "hp": 60,
+            "attack": 78,
+            "defense": 135,
+            "sp.atk": 91,
+            "sp.def": 85,
+            "speed": 36,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Togedemaru": {
+        "name": "Togedemaru",
+        "species": "Roly-Poly Pokemon",
+        "id": "777",
+        "type": [
+            "Electric",
+            "Steel"
+        ],
+        "height": "(0.3m)",
+        "weight": "(3.3 kg)",
+        "abilities": [
+            "Iron Barbs",
+            "Lightningrod",
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 65,
+            "attack": 98,
+            "defense": 63,
+            "sp.atk": 40,
+            "sp.def": 73,
+            "speed": 96,
+            "total": 435
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Mimikyu": {
+        "name": "Mimikyu",
+        "species": "Disguise Pokemon",
+        "id": "778",
+        "type": [
+            "Ghost",
+            "Fairy"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.7 kg)",
+        "abilities": [
+            "Disguise"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 90,
+            "defense": 80,
+            "sp.atk": 50,
+            "sp.def": 105,
+            "speed": 96,
+            "total": 476
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Bruxish": {
+        "name": "Bruxish",
+        "species": "Gnash Teeth Pokemon",
+        "id": "779",
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "height": "(0.9m)",
+        "weight": "(19 kg)",
+        "abilities": [
+            "Dazzling",
+            "Strong Jaw",
+            "Wonder Skin "
+        ],
+        "stats": {
+            "hp": 68,
+            "attack": 105,
+            "defense": 70,
+            "sp.atk": 70,
+            "sp.def": 70,
+            "speed": 92,
+            "total": 475
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Drampa": {
+        "name": "Drampa",
+        "species": "Placid Pokemon",
+        "id": "780",
+        "type": [
+            "Normal",
+            "Dragon"
+        ],
+        "height": "(3m)",
+        "weight": "(185 kg)",
+        "abilities": [
+            "Berserk",
+            "Sap Sipper",
+            "Cloud Nine"
+        ],
+        "stats": {
+            "hp": 78,
+            "attack": 60,
+            "defense": 85,
+            "sp.atk": 135,
+            "sp.def": 91,
+            "speed": 36,
+            "total": 485
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Dhelmise": {
+        "name": "Dhelmise",
+        "species": "Sea Creeper Pokemon",
+        "id": "781",
+        "type": [
+            "Ghost",
+            "Grass"
+        ],
+        "height": "(3.9m)",
+        "weight": "(210 kg)",
+        "abilities": [
+            "Steelworker"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 131,
+            "defense": 100,
+            "sp.atk": 86,
+            "sp.def": 90,
+            "speed": 40,
+            "total": 517
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Jangmo-o": {
+        "name": "Jangmo-o",
+        "species": "Scaly Pokemon",
+        "id": "782",
+        "type": [
+            "Dragon"
+        ],
+        "height": "(0.6m)",
+        "weight": "(29.7 kg)",
+        "abilities": [
+            "Bulletproof",
+            "Soundproof",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 45,
+            "attack": 55,
+            "defense": 65,
+            "sp.atk": 45,
+            "sp.def": 45,
+            "speed": 45,
+            "total": 300
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Hakamo-o": {
+        "name": "Hakamo-o",
+        "species": "Scaly Pokemon",
+        "id": "783",
+        "type": [
+            "Dragon",
+            "Fighting"
+        ],
+        "height": "(1.2m)",
+        "weight": "(47 kg)",
+        "abilities": [
+            "Bulletproof",
+            "Soundproof",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 55,
+            "attack": 75,
+            "defense": 90,
+            "sp.atk": 65,
+            "sp.def": 70,
+            "speed": 65,
+            "total": 420
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Kommo-o": {
+        "name": "Kommo-o",
+        "species": "Scaly Pokemon",
+        "id": "784",
+        "type": [
+            "Dragon",
+            "Fighting"
+        ],
+        "height": "(1.6m)",
+        "weight": "(78.2 kg)",
+        "abilities": [
+            "Bulletproof",
+            "Soundproof",
+            "Overcoat"
+        ],
+        "stats": {
+            "hp": 75,
+            "attack": 110,
+            "defense": 125,
+            "sp.atk": 100,
+            "sp.def": 105,
+            "speed": 85,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Tapu Koko": {
+        "name": "Tapu Koko",
+        "species": "Land Spirit Pokemon",
+        "id": "785",
+        "type": [
+            "Electric",
+            "Fairy"
+        ],
+        "height": "(1.8m)",
+        "weight": "(20.5 kg)",
+        "abilities": [
+            "Electric Surge",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 115,
+            "defense": 85,
+            "sp.atk": 95,
+            "sp.def": 75,
+            "speed": 130,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Tapu Lele": {
+        "name": "Tapu Lele",
+        "species": "Land Spirit Pokemon",
+        "id": "786",
+        "type": [
+            "Psychic",
+            "Fairy"
+        ],
+        "height": "(1.2m)",
+        "weight": "(18.6 kg)",
+        "abilities": [
+            "Psychic Surge",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 85,
+            "defense": 75,
+            "sp.atk": 130,
+            "sp.def": 115,
+            "speed": 95,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Tapu Bulu": {
+        "name": "Tapu Bulu",
+        "species": "Land Spirit Pokemon",
+        "id": "787",
+        "type": [
+            "Grass",
+            "Fairy"
+        ],
+        "height": "(1.9m)",
+        "weight": "(45.5 kg)",
+        "abilities": [
+            "Grassy Surge",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 130,
+            "defense": 115,
+            "sp.atk": 85,
+            "sp.def": 95,
+            "speed": 75,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Tapu Fini": {
+        "name": "Tapu Fini",
+        "species": "Land Spirit Pokemon",
+        "id": "788",
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "height": "(1.3m)",
+        "weight": "(21.2 kg)",
+        "abilities": [
+            "Misty Surge",
+            "Telepathy"
+        ],
+        "stats": {
+            "hp": 70,
+            "attack": 75,
+            "defense": 115,
+            "sp.atk": 95,
+            "sp.def": 130,
+            "speed": 85,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Cosmog": {
+        "name": "Cosmog",
+        "species": "Nebula Pokemon",
+        "id": "789",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.2m)",
+        "weight": "(0.1 kg)",
+        "abilities": [
+            "Unaware"
+        ],
+        "stats": {
+            "hp": 43,
+            "attack": 29,
+            "defense": 31,
+            "sp.atk": 29,
+            "sp.def": 31,
+            "speed": 37,
+            "total": 200
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Cosmoem": {
+        "name": "Cosmoem",
+        "species": "Protostar Pokemon",
+        "id": "790",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(0.1m)",
+        "weight": "(999.9 kg)",
+        "abilities": [
+            "Sturdy"
+        ],
+        "stats": {
+            "hp": 43,
+            "attack": 29,
+            "defense": 131,
+            "sp.atk": 29,
+            "sp.def": 131,
+            "speed": 37,
+            "total": 400
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Solgaleo": {
+        "name": "Solgaleo",
+        "species": "Sunne Pokemon",
+        "id": "791",
+        "type": [
+            "Psychic",
+            "Steel"
+        ],
+        "height": "(3.4m)",
+        "weight": "(230 kg)",
+        "abilities": [
+            "Full Metal Body"
+        ],
+        "stats": {
+            "hp": 137,
+            "attack": 137,
+            "defense": 107,
+            "sp.atk": 113,
+            "sp.def": 89,
+            "speed": 97,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Lunala": {
+        "name": "Lunala",
+        "species": "Moone Pokemon",
+        "id": "792",
+        "type": [
+            "Psychic",
+            "Ghost"
+        ],
+        "height": "(4m)",
+        "weight": "(120 kg)",
+        "abilities": [
+            "Shadow Shield"
+        ],
+        "stats": {
+            "hp": 137,
+            "attack": 113,
+            "defense": 89,
+            "sp.atk": 137,
+            "sp.def": 107,
+            "speed": 97,
+            "total": 680
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Nihilego": {
+        "name": "Nihilego",
+        "species": "Parasite Pokemon",
+        "id": "793",
+        "type": [
+            "Rock",
+            "Poison"
+        ],
+        "height": "(1.2m)",
+        "weight": "(55.5 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 109,
+            "attack": 53,
+            "defense": 47,
+            "sp.atk": 127,
+            "sp.def": 131,
+            "speed": 103,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Buzzwole": {
+        "name": "Buzzwole",
+        "species": "Swollen Pokemon",
+        "id": "794",
+        "type": [
+            "Bug",
+            "Fighting"
+        ],
+        "height": "(2.4m)",
+        "weight": "(333.6 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 107,
+            "attack": 139,
+            "defense": 139,
+            "sp.atk": 53,
+            "sp.def": 53,
+            "speed": 79,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Pheromosa": {
+        "name": "Pheromosa",
+        "species": "Lissome Pokemon",
+        "id": "795",
+        "type": [
+            "Bug",
+            "Fighting"
+        ],
+        "height": "(1.8m)",
+        "weight": "(25 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 71,
+            "attack": 137,
+            "defense": 37,
+            "sp.atk": 137,
+            "sp.def": 37,
+            "speed": 151,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Xurkitree": {
+        "name": "Xurkitree",
+        "species": "Glowing Pokemon",
+        "id": "796",
+        "type": [
+            "Electric"
+        ],
+        "height": "(3.8m)",
+        "weight": "(100 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 83,
+            "attack": 89,
+            "defense": 71,
+            "sp.atk": 173,
+            "sp.def": 71,
+            "speed": 83,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Celesteela": {
+        "name": "Celesteela",
+        "species": "Launch Pokemon",
+        "id": "797",
+        "type": [
+            "Steel",
+            "Flying"
+        ],
+        "height": "(9.2m)",
+        "weight": "(999.9 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 97,
+            "attack": 101,
+            "defense": 103,
+            "sp.atk": 107,
+            "sp.def": 101,
+            "speed": 61,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Kartana": {
+        "name": "Kartana",
+        "species": "Drawn Sword Pokemon",
+        "id": "798",
+        "type": [
+            "Grass",
+            "Steel"
+        ],
+        "height": "(0.3m)",
+        "weight": "(0.1 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 59,
+            "attack": 181,
+            "defense": 131,
+            "sp.atk": 59,
+            "sp.def": 31,
+            "speed": 109,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Guzzlord": {
+        "name": "Guzzlord",
+        "species": "Junkivore Pokemon",
+        "id": "799",
+        "type": [
+            "Dark",
+            "Dragon"
+        ],
+        "height": "(5.5m)",
+        "weight": "(888 kg)",
+        "abilities": [
+            "Beast Boost"
+        ],
+        "stats": {
+            "hp": 223,
+            "attack": 101,
+            "defense": 53,
+            "sp.atk": 97,
+            "sp.def": 53,
+            "speed": 43,
+            "total": 570
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Necrozma": {
+        "name": "Necrozma",
+        "species": "Prism Pokemon",
+        "id": "800",
+        "type": [
+            "Psychic"
+        ],
+        "height": "(2.4m)",
+        "weight": "(230 kg)",
+        "abilities": [
+            "Prism Armor"
+        ],
+        "stats": {
+            "hp": 97,
+            "attack": 107,
+            "defense": 101,
+            "sp.atk": 127,
+            "sp.def": 89,
+            "speed": 79,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    },
+    "Magearna": {
+        "name": "Magearna",
+        "species": "Artificial Pokemon",
+        "id": "801",
+        "type": [
+            "Steel",
+            "Fairy"
+        ],
+        "height": "(1m)",
+        "weight": "(80.5 kg)",
+        "abilities": [
+            "Soul-Heart"
+        ],
+        "stats": {
+            "hp": 80,
+            "attack": 95,
+            "defense": 115,
+            "sp.atk": 130,
+            "sp.def": 115,
+            "speed": 65,
+            "total": 600
+        },
+        "evolution": [],
+        "description": "Description not available yet",
+        "gen": 7
+    }
+}


### PR DESCRIPTION
Hi! In this PR, I propose adding a Pokemon dataset JSON file to the data directory. The reasoning behind adding this file is that it could allow us to perform more complicated queries regarding the Pokemon.

The file was obtained from here: https://www.kaggle.com/rajgaurav9/pokemon-stats-and-description-with-pictures-json

However, I slightly modified the JSON to have the Pokemon names as keys, in case we need to do a quick lookup.

@koaning in issue #5, you mentioned your idea of hosting the images somewhere. So, I'll leave that to you.

Below is an example of a Pokemon:

```json
{
    "Bulbasaur": {
        "id": "001",
        "name": "Bulbasaur",
        "species": "Seed Pokemon",
        "type": [
            "Grass",
            "Poison"
        ],
        "height": "2ft.4in. (0.71m)",
        "weight": "15.2 lbs (6.9 kg)",
        "abilities": [
            "Overgrow",
            "Chlorophyll"
        ],
        "stats": {
            "hp": 45,
            "attack": 49,
            "defense": 49,
            "sp.atk": 65,
            "sp.def": 65,
            "speed": 45,
            "total": 318
        },
        "evolution": [
            "Bulbasaur",
            "Ivysaur",
            "Venusaur"
        ],
        "description": "For some time after its birth, it grows by gaining nourishment from the seed on its back.",
        "gen": 1
    },
```