### PR TITLE
Added action_translate_name to enable translations

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -37,6 +37,8 @@ class ActionTranslateName(Action):
     with open("data/pokemondb.json") as pokemon_db:
         knowledge = json.load(pokemon_db)
 
+    languages = Path("data/languages.txt").read_text().split("\n")
+
     def name(self) -> Text:
         return "action_translate_name"
 
@@ -53,26 +55,30 @@ class ActionTranslateName(Action):
             if blob['entity'] == 'pokemon_name':
                 name = blob['value']
 
-        # Resolve the action.
+        # Now we resolve the action.
+        # But first, let's check if the Pokemon and language entity are valid.
         if name is None:
             dispatcher.utter_message(
-                text=f"I do not recognize that Pokemon, are you sure it is correctly spelled?")
-        else:
-            for pokemon in self.knowledge['pokemon']:
-                if pokemon['name'] == name:
-                    # Get the translated name.
-                    translated_name = pokemon.get(
-                        'name_language', {}).get(language)
+                text=f"I do not recognize that name.")
+            return []
 
-                    # If a translation exists (for the given language).
-                    if translated_name:
-                        dispatcher.utter_message(
-                            text=f"{name}'s {language} name is {translated_name}."
-                        )
-                    else:
-                        dispatcher.utter_message(
-                            text=f"I don't know that translation."
-                        )
+        if language not in self.languages:
+            dispatcher.utter_message(
+                text=f"I do not yet support that language.")
+            return []
+
+        # If the Pokemon and language are found...
+        for pokemon in self.knowledge['pokemon']:
+            if pokemon['name'] != name:
+                continue
+
+            # Get the translated name.
+            translated_name = pokemon.get(
+                'name_language', {}).get(language)
+
+            dispatcher.utter_message(
+                text=f"{name}'s {language} name is {translated_name}."
+            )
 
         return []
 

--- a/data/languages.txt
+++ b/data/languages.txt
@@ -1,0 +1,2 @@
+french
+german

--- a/data/nlu.md
+++ b/data/nlu.md
@@ -86,7 +86,7 @@
 
 ## intent:name_translation
 - What is the [french](language) name of [Snorlax](pokemon_name)?
-- Do you know how [Snorlax](pokemon_name) is called in [spanish](language)?
+- Do you know how [Mewtwo](pokemon_name) is called in [german](language)?
 - Translate [Snorlax](pokemon_name) to [german](language).
 
 ## intent:faq/what_is_pokemon
@@ -119,3 +119,6 @@
 
 ## lookup:pokemon_name
   data/pokenames.txt
+
+## lookup:languages
+  data/languages.txt

--- a/data/nlu.md
+++ b/data/nlu.md
@@ -86,8 +86,8 @@
 
 ## intent:name_translation
 - What is the [french](language) name of [Snorlax](pokemon_name)?
-- What is the [spanish](language) name of [Snorlax](pokemon_name)?
-- What is the [german](language) name of [Snorlax](pokemon_name)?
+- Do you know how [Snorlax](pokemon_name) is called in [spanish](language)?
+- Translate [Snorlax](pokemon_name) to [german](language).
 
 ## intent:faq/what_is_pokemon
 - what is pokemon?

--- a/data/nlu.md
+++ b/data/nlu.md
@@ -84,6 +84,11 @@
 - are [pichuka](pokemon_name) and [charmander](pokemon_name) pokemon?
 - are [snorlax](pokemon_name), [gariddos](pokemon_name) and [dittto](pokemon_name) pokemon?
 
+## intent:name_translation
+- What is the [french](language) name of [Snorlax](pokemon_name)?
+- What is the [spanish](language) name of [Snorlax](pokemon_name)?
+- What is the [german](language) name of [Snorlax](pokemon_name)?
+
 ## intent:faq/what_is_pokemon
 - what is pokemon?
 - can you tell me what pokemon is?

--- a/data/pokemondb.json
+++ b/data/pokemondb.json
@@ -29,7 +29,11 @@
                 "Venusaur"
             ],
             "description": "For some time after its birth, it grows by gaining nourishment from the seed on its back.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Bulbizarre",
+                "german": "Bisasam"
+            }
         },
         {
             "id": 2,
@@ -60,7 +64,11 @@
                 "Venusaur"
             ],
             "description": "When the bud on its back starts swelling, a sweet aroma wafts to indicate the flowers coming bloom.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Herbizarre",
+                "german": "Bisaknosp"
+            }
         },
         {
             "id": 3,
@@ -91,7 +99,11 @@
                 "Venusaur"
             ],
             "description": "After a rainy day, the flower on its back smells stronger. The scent attracts other Pokemon.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Florizarre",
+                "german": "Bisaflor"
+            }
         },
         {
             "id": 4,
@@ -121,7 +133,11 @@
                 "Charizard"
             ],
             "description": "The fire on the tip of its tail is a measure of its life. If healthy, its tail burns intensely.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Salam\u00e8che",
+                "german": "Glumanda"
+            }
         },
         {
             "id": 5,
@@ -151,7 +167,11 @@
                 "Charizard"
             ],
             "description": "In the rocky mountains where Charmeleon live, their fiery tails shine at night like stars.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Reptincel",
+                "german": "Glutexo"
+            }
         },
         {
             "id": 6,
@@ -182,7 +202,11 @@
                 "Charizard"
             ],
             "description": "It is said that Charizards fire burns hotter if it has experienced harsh battles.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Dracaufeu",
+                "german": "Glurak"
+            }
         },
         {
             "id": 7,
@@ -212,7 +236,11 @@
                 "Blastoise"
             ],
             "description": "It shelters itself in its shell then strikes back with spouts of water at every opportunity.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Carapuce",
+                "german": "Schiggy"
+            }
         },
         {
             "id": 8,
@@ -242,7 +270,11 @@
                 "Blastoise"
             ],
             "description": "It is said to live 10,000 years. Its furry tail is popular as a symbol of longevity.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Carabaffe",
+                "german": "Schillok"
+            }
         },
         {
             "id": 9,
@@ -272,7 +304,11 @@
                 "Blastoise"
             ],
             "description": "The jets of water it spouts from the rocket cannons on its shell can punch through thick steel.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tortank",
+                "german": "Turtok"
+            }
         },
         {
             "id": 10,
@@ -302,7 +338,11 @@
                 "Butterfree"
             ],
             "description": "It releases a stench from its red antenna to repel enemies. It grows by molting repeatedly.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Chenipan",
+                "german": "Raupy"
+            }
         },
         {
             "id": 11,
@@ -331,7 +371,11 @@
                 "Butterfree"
             ],
             "description": "A steel-hard shell protects its tender body. It quietly endures hardships while awaiting evolution.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Chrysacier",
+                "german": "Safcon"
+            }
         },
         {
             "id": 12,
@@ -362,7 +406,11 @@
                 "Butterfree"
             ],
             "description": "It loves the honey of flowers and can locate flower patches that have even tiny amounts of pollen.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Papilusion",
+                "german": "Smettbo"
+            }
         },
         {
             "id": 13,
@@ -393,7 +441,11 @@
                 "Beedrill"
             ],
             "description": "It eats its weight in leaves every day. It fends off attackers with the needle on its head.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Aspicot",
+                "german": "Hornliu"
+            }
         },
         {
             "id": 14,
@@ -423,7 +475,11 @@
                 "Beedrill"
             ],
             "description": "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Coconfort",
+                "german": "Kokuna"
+            }
         },
         {
             "id": 15,
@@ -454,7 +510,11 @@
                 "Beedrill"
             ],
             "description": "Its best attack involves flying around at high speed, striking with poison needles, then flying off.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Dardargnan",
+                "german": "Bibor"
+            }
         },
         {
             "id": 16,
@@ -486,7 +546,11 @@
                 "Pidgeot"
             ],
             "description": "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Roucool",
+                "german": "Taubsi"
+            }
         },
         {
             "id": 17,
@@ -518,7 +582,11 @@
                 "Pidgeot"
             ],
             "description": "It flies over its wide territory in search of prey, downing it with its highly developed claws.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Roucoups",
+                "german": "Tauboga"
+            }
         },
         {
             "id": 18,
@@ -550,7 +618,11 @@
                 "Pidgeot"
             ],
             "description": "It flies over its wide territory in search of prey, downing it with its highly developed claws.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Roucarnage",
+                "german": "Tauboss"
+            }
         },
         {
             "id": 19,
@@ -580,7 +652,11 @@
                 "Raticate"
             ],
             "description": "It searches for food all day. It gnaws on hard objects to wear down its fangs, which grow constantly during its lifetime.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rattata",
+                "german": "Rattfratz"
+            }
         },
         {
             "id": 20,
@@ -610,7 +686,11 @@
                 "Raticate"
             ],
             "description": "With its long fangs, this surprisingly violent Pokemon can gnaw away even thick concrete with ease.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rattatac",
+                "german": "Rattikarl"
+            }
         },
         {
             "id": 21,
@@ -640,7 +720,11 @@
                 "Fearow"
             ],
             "description": "It flaps its small wings busily to fly. Using its beak, it searches in grass for prey.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Piafabec",
+                "german": "Habitak"
+            }
         },
         {
             "id": 22,
@@ -670,7 +754,11 @@
                 "Fearow"
             ],
             "description": "It has the stamina to fly all day on its broad wings. It fights by using its sharp beak.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rapasdepic",
+                "german": "Ibitak"
+            }
         },
         {
             "id": 23,
@@ -700,7 +788,11 @@
                 "Arbok"
             ],
             "description": "It sneaks through grass without making a sound and strikes unsuspecting prey from behind.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Abo",
+                "german": "Rettan"
+            }
         },
         {
             "id": 24,
@@ -730,7 +822,11 @@
                 "Arbok"
             ],
             "description": "The pattern on its belly is for intimidation. It constricts foes while they are frozen in fear.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Arbok",
+                "german": "Arbok"
+            }
         },
         {
             "id": 25,
@@ -759,7 +855,11 @@
                 "Raichu"
             ],
             "description": "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Pikachu",
+                "german": "Pikachu"
+            }
         },
         {
             "id": 26,
@@ -788,7 +888,11 @@
                 "Raichu"
             ],
             "description": "Its tail discharges electricity into the ground, protecting it from getting shocked.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Raichu",
+                "german": "Raichu"
+            }
         },
         {
             "id": 27,
@@ -817,7 +921,11 @@
                 "Sandslash"
             ],
             "description": "It digs deep burrows to live in. When in danger, it rolls up its body to withstand attacks.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Sabelette",
+                "german": "Sandan"
+            }
         },
         {
             "id": 28,
@@ -846,7 +954,11 @@
                 "Sandslash"
             ],
             "description": "The spikes on its body are made up of its hardened hide. It rolls up and attacks foes with its spikes.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Sablaireau",
+                "german": "Sandamer"
+            }
         },
         {
             "id": 29,
@@ -877,7 +989,11 @@
                 "Nidoqueen"
             ],
             "description": "While it does not prefer to fight, even one drop of the poison it secretes from barbs can be fatal.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidoran\u2640",
+                "german": "Nidoran\u2640"
+            }
         },
         {
             "id": 30,
@@ -908,7 +1024,11 @@
                 "Nidoqueen"
             ],
             "description": "When it senses danger, it raises all the barbs on its body. These barbs grow slower than Nidorinos.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidorina",
+                "german": "Nidorina"
+            }
         },
         {
             "id": 31,
@@ -940,7 +1060,11 @@
                 "Nidoqueen"
             ],
             "description": "Its entire body is armored with hard scales. It will protect the young in its burrow with its life.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidoqueen",
+                "german": "Nidoqueen"
+            }
         },
         {
             "id": 32,
@@ -971,7 +1095,11 @@
                 "Nidoking"
             ],
             "description": "It scans its surroundings by raising its ears out of the grass. Its toxic horn is for protection.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidoran\u2642",
+                "german": "Nidoran\u2642"
+            }
         },
         {
             "id": 33,
@@ -1002,7 +1130,11 @@
                 "Nidoking"
             ],
             "description": "It has a violent disposition and stabs foes with its horn, which oozes poison upon impact.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidorino",
+                "german": "Nidorino"
+            }
         },
         {
             "id": 34,
@@ -1034,7 +1166,11 @@
                 "Nidoking"
             ],
             "description": "One swing of its mighty tail can snap a telephone pole as if it were a matchstick.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nidoking",
+                "german": "Nidoking"
+            }
         },
         {
             "id": 35,
@@ -1065,7 +1201,11 @@
                 "Clefable"
             ],
             "description": "On nights with a full moon, Clefairy gather from all over and dance. Bathing in moonlight makes them float.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "M\u00e9lof\u00e9e",
+                "german": "Piepi"
+            }
         },
         {
             "id": 36,
@@ -1096,7 +1236,11 @@
                 "Clefable"
             ],
             "description": "Their ears are sensitive enough to hear a pin drop from over a mile away, so theyre usually found in quiet places.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "M\u00e9lodelfe",
+                "german": "Pixi"
+            }
         },
         {
             "id": 37,
@@ -1125,7 +1269,11 @@
                 "Ninetales"
             ],
             "description": "As each tail grows, its fur becomes more lustrous. When held, it feels slightly warm.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Goupix",
+                "german": "Vulpix"
+            }
         },
         {
             "id": 38,
@@ -1154,7 +1302,11 @@
                 "Ninetales"
             ],
             "description": "Each of its nine tails is imbued with supernatural power, and it can live for a thousand years.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Feunard",
+                "german": "Vulnona"
+            }
         },
         {
             "id": 39,
@@ -1185,7 +1337,11 @@
                 "Wigglytuff"
             ],
             "description": "Looking into its cute, round eyes makes it start singing a song so pleasant listeners cant help but fall asleep.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rondoudou",
+                "german": "Pummeluff"
+            }
         },
         {
             "id": 40,
@@ -1216,7 +1372,11 @@
                 "Wigglytuff"
             ],
             "description": "Its fine fur feels so pleasant, those who accidentally touch it cannot take their hands away.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Grodoudou",
+                "german": "Knuddeluff"
+            }
         },
         {
             "id": 41,
@@ -1247,7 +1407,11 @@
                 "Crobat"
             ],
             "description": "It does not need eyes, because it emits ultrasonic waves to check its surroundings while it flies.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nosferapti",
+                "german": "Zubat"
+            }
         },
         {
             "id": 42,
@@ -1278,7 +1442,11 @@
                 "Crobat"
             ],
             "description": "Flitting around in the dead of night, it sinks its fangs into its prey and drains a nearly fatal amount of blood.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Nosferalto",
+                "german": "Golbat"
+            }
         },
         {
             "id": 43,
@@ -1309,7 +1477,11 @@
                 "Vileplume"
             ],
             "description": "It often plants its root feet in the ground during the day and sows seeds as it walks about at night.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Mystherbe",
+                "german": "Myrapla"
+            }
         },
         {
             "id": 44,
@@ -1340,7 +1512,11 @@
                 "Vileplume"
             ],
             "description": "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ortide",
+                "german": "Duflor"
+            }
         },
         {
             "id": 45,
@@ -1371,7 +1547,11 @@
                 "Vileplume"
             ],
             "description": "Its petals are the largest in the world. As it walks, it scatters extremely allergenic pollen.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rafflesia",
+                "german": "Giflor"
+            }
         },
         {
             "id": 46,
@@ -1402,7 +1582,11 @@
                 "Parasect"
             ],
             "description": "Mushrooms named tochukaso grow on its back. They grow along with the host Paras.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Paras",
+                "german": "Paras"
+            }
         },
         {
             "id": 47,
@@ -1433,7 +1617,11 @@
                 "Parasect"
             ],
             "description": "A mushroom grown larger than the hosts body controls Parasect. It scatters poisonous spores.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Parasect",
+                "german": "Parasek"
+            }
         },
         {
             "id": 48,
@@ -1464,7 +1652,11 @@
                 "Venomoth"
             ],
             "description": "Its big eyes are actually clusters of tiny eyes. At night, its kind is drawn by light.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Mimitoss",
+                "german": "Bluzuk"
+            }
         },
         {
             "id": 49,
@@ -1495,7 +1687,11 @@
                 "Venomoth"
             ],
             "description": "It flutters its wings to scatter dustlike scales. The scales leach toxins if they contact skin.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "A\u00e9romite",
+                "german": "Omot"
+            }
         },
         {
             "id": 50,
@@ -1525,7 +1721,11 @@
                 "Dugtrio"
             ],
             "description": "A Pokemon that lives underground. Because of its dark habitat, it is repelled by bright sunlight.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Taupiqueur",
+                "german": "Digda"
+            }
         },
         {
             "id": 51,
@@ -1555,7 +1755,11 @@
                 "Dugtrio"
             ],
             "description": "Its three heads move alternately, driving it through tough soil to depths of over 60 miles.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Triopikeur",
+                "german": "Digdri"
+            }
         },
         {
             "id": 52,
@@ -1585,7 +1789,11 @@
                 "Persian"
             ],
             "description": "It is nocturnal in nature. If it spots something shiny, its eyes glitter brightly.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Miaouss",
+                "german": "Mauzi"
+            }
         },
         {
             "id": 53,
@@ -1615,7 +1823,11 @@
                 "Persian"
             ],
             "description": "A very haughty Pokemon. Among fans, the size of the jewel in its forehead is a topic of much talk.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Persian",
+                "german": "Snobilikat"
+            }
         },
         {
             "id": 54,
@@ -1645,7 +1857,11 @@
                 "Golduck"
             ],
             "description": "When headaches stimulate its brain cells, which are usually inactive, it can use a mysterious power.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Psykokwak",
+                "german": "Enton"
+            }
         },
         {
             "id": 55,
@@ -1675,7 +1891,11 @@
                 "Golduck"
             ],
             "description": "When its forehead shines mysteriously, Golduck can use the full extent of its power.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Akwakwak",
+                "german": "Entoron"
+            }
         },
         {
             "id": 56,
@@ -1705,7 +1925,11 @@
                 "Primeape"
             ],
             "description": "It lives in treetop colonies. If one becomes enraged, the whole colony rampages for no reason.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "F\u00e9rosinge",
+                "german": "Menki"
+            }
         },
         {
             "id": 57,
@@ -1735,7 +1959,11 @@
                 "Primeape"
             ],
             "description": "It grows angry if you see its eyes and gets angrier if you run. If you beat it, it gets even madder.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Colossinge",
+                "german": "Rasaff"
+            }
         },
         {
             "id": 58,
@@ -1765,7 +1993,11 @@
                 "Arcanine"
             ],
             "description": "Extremely loyal to its Trainer, it will bark at those who approach the Trainer unexpectedly and run them out of town.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Caninos",
+                "german": "Fukano"
+            }
         },
         {
             "id": 59,
@@ -1795,7 +2027,11 @@
                 "Arcanine"
             ],
             "description": "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Arcanin",
+                "german": "Arkani"
+            }
         },
         {
             "id": 60,
@@ -1826,7 +2062,11 @@
                 "Poliwrath"
             ],
             "description": "Its skin is so thin, its internal organs are visible. It has trouble walking on its newly grown feet.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ptitard",
+                "german": "Quapsel"
+            }
         },
         {
             "id": 61,
@@ -1857,7 +2097,11 @@
                 "Poliwrath"
             ],
             "description": "The spiral pattern on its belly subtly undulates. Staring at it gradually causes drowsiness.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "T\u00eatarte",
+                "german": "Quaputzi"
+            }
         },
         {
             "id": 62,
@@ -1889,7 +2133,11 @@
                 "Poliwrath"
             ],
             "description": "With its extremely tough muscles, it can keep swimming in the Pacific Ocean without resting.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tartard",
+                "german": "Quappo"
+            }
         },
         {
             "id": 63,
@@ -1920,7 +2168,11 @@
                 "Alakazam"
             ],
             "description": "Using its psychic power is such a strain on its brain that it needs to sleep for 18 hours a day.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Abra",
+                "german": "Abra"
+            }
         },
         {
             "id": 64,
@@ -1951,7 +2203,11 @@
                 "Alakazam"
             ],
             "description": "It stares at its silver spoon to focus its mind. It emits more alpha waves while doing so.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kadabra",
+                "german": "Kadabra"
+            }
         },
         {
             "id": 65,
@@ -1982,7 +2238,11 @@
                 "Alakazam"
             ],
             "description": "The spoons clutched in its hands are said to have been created by its psychic powers.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Alakazam",
+                "german": "Simsala"
+            }
         },
         {
             "id": 66,
@@ -2013,7 +2273,11 @@
                 "Machamp"
             ],
             "description": "Though small in stature, it is powerful enough to easily heft and throw a number of Geodude at once.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Machoc",
+                "german": "Machollo"
+            }
         },
         {
             "id": 67,
@@ -2044,7 +2308,11 @@
                 "Machamp"
             ],
             "description": "It happily carries heavy cargo to toughen up. It willingly does hard work for people.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Machopeur",
+                "german": "Maschock"
+            }
         },
         {
             "id": 68,
@@ -2075,7 +2343,11 @@
                 "Machamp"
             ],
             "description": "Its four muscled arms slam foes with powerful punches and chops at blinding speed.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Mackogneur",
+                "german": "Machomei"
+            }
         },
         {
             "id": 69,
@@ -2106,7 +2378,11 @@
                 "Victreebel"
             ],
             "description": "It prefers hot and humid environments. It is quick at capturing prey with its vines.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ch\u00e9tiflor",
+                "german": "Knofensa"
+            }
         },
         {
             "id": 70,
@@ -2137,7 +2413,11 @@
                 "Victreebel"
             ],
             "description": "A Pokemon that appears to be a plant. It captures unwary prey by dousing them with a toxic powder.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Boustiflor",
+                "german": "Ultrigaria"
+            }
         },
         {
             "id": 71,
@@ -2168,7 +2448,11 @@
                 "Victreebel"
             ],
             "description": "It pools in its mouth a fluid with a honey-like scent, which is really an acid that dissolves anything.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Empiflor",
+                "german": "Sarzenia"
+            }
         },
         {
             "id": 72,
@@ -2199,7 +2483,11 @@
                 "Tentacruel"
             ],
             "description": "Because its body is almost entirely composed of water, it shrivels up if it is washed ashore.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tentacool",
+                "german": "Tentacha"
+            }
         },
         {
             "id": 73,
@@ -2230,7 +2518,11 @@
                 "Tentacruel"
             ],
             "description": "It extends its 80 tentacles to form an encircling poisonous net that is difficult to escape.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tentacruel",
+                "german": "Tentoxa"
+            }
         },
         {
             "id": 74,
@@ -2262,7 +2554,11 @@
                 "Golem"
             ],
             "description": "At rest, it looks just like a rock. Carelessly stepping on it will make it swing its fists angrily.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Racaillou",
+                "german": "Kleinstein"
+            }
         },
         {
             "id": 75,
@@ -2294,7 +2590,11 @@
                 "Golem"
             ],
             "description": "It rolls on mountain paths to move. Once it builds momentum, no Pokemon can stop it without difficulty.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Gravalanch",
+                "german": "Georok"
+            }
         },
         {
             "id": 76,
@@ -2326,7 +2626,11 @@
                 "Golem"
             ],
             "description": "Even dynamite cant harm its hard, boulder-like body. It sheds its hide just once a year.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Grolem",
+                "german": "Geowaz"
+            }
         },
         {
             "id": 77,
@@ -2356,7 +2660,11 @@
                 "Rapidash"
             ],
             "description": "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ponyta",
+                "german": "Ponita"
+            }
         },
         {
             "id": 78,
@@ -2386,7 +2694,11 @@
                 "Rapidash"
             ],
             "description": "When at an all-out gallop, its blazing mane sparkles, enhancing its beautiful appearance.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Galopa",
+                "german": "Gallopa"
+            }
         },
         {
             "id": 79,
@@ -2417,7 +2729,11 @@
                 "Slowbro"
             ],
             "description": "Although slow, it is skilled at fishing with its tail. It does not feel pain if its tail is bitten.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ramoloss",
+                "german": "Flegmon"
+            }
         },
         {
             "id": 80,
@@ -2448,7 +2764,11 @@
                 "Slowbro"
             ],
             "description": "Though usually dim witted, it seems to become inspired if the Shellder on its tail bites down.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Flagadoss",
+                "german": "Lahmus"
+            }
         },
         {
             "id": 81,
@@ -2479,7 +2799,11 @@
                 "Magneton"
             ],
             "description": "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Magn\u00e9ti",
+                "german": "Magnetilo"
+            }
         },
         {
             "id": 82,
@@ -2510,7 +2834,11 @@
                 "Magneton"
             ],
             "description": "The stronger electromagnetic waves from the three linked Magnemite are enough to dry out surrounding moisture.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Magn\u00e9ton",
+                "german": "Magneton"
+            }
         },
         {
             "id": 83,
@@ -2538,7 +2866,11 @@
             },
             "evolution": [],
             "description": "It cant live without the stalk it holds. Thats why it defends the stalk from attackers with its life.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Canarticho",
+                "german": "Porenta"
+            }
         },
         {
             "id": 84,
@@ -2569,7 +2901,11 @@
                 "Dodrio"
             ],
             "description": "The brains in its two heads appear to communicate emotions to each other with a telepathic power.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Doduo",
+                "german": "Dodu"
+            }
         },
         {
             "id": 85,
@@ -2600,7 +2936,11 @@
                 "Dodrio"
             ],
             "description": "When Doduo evolves into this odd breed, one of its heads splits into two. It runs at nearly 40 mph.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Dodrio",
+                "german": "Dodri"
+            }
         },
         {
             "id": 86,
@@ -2630,7 +2970,11 @@
                 "Dewgong"
             ],
             "description": "The colder it gets, the better it feels. It joyfully swims around oceans so cold that they are filled with floating ice.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Otaria",
+                "german": "Jurob"
+            }
         },
         {
             "id": 87,
@@ -2661,7 +3005,11 @@
                 "Dewgong"
             ],
             "description": "Its streamlined body has low resistance, and it swims around cold oceans at a speed of eight knots.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Lamantine",
+                "german": "Jugong"
+            }
         },
         {
             "id": 88,
@@ -2691,7 +3039,11 @@
                 "Muk"
             ],
             "description": "Born from sludge, these Pokemon now gather in polluted places and increase the bacteria in their bodies.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tadmorv",
+                "german": "Sleima"
+            }
         },
         {
             "id": 89,
@@ -2721,7 +3073,11 @@
                 "Muk"
             ],
             "description": "Its so stinky! Muks body contains toxic elements, and any plant will wilt when it passes by.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Grotadmorv",
+                "german": "Sleimok"
+            }
         },
         {
             "id": 90,
@@ -2751,7 +3107,11 @@
                 "Cloyster"
             ],
             "description": "It swims backward by opening and closing its two shells. Its large tongue is always kept hanging out.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kokiyas",
+                "german": "Muschas"
+            }
         },
         {
             "id": 91,
@@ -2782,7 +3142,11 @@
                 "Cloyster"
             ],
             "description": "It fights by keeping its shell tightly shut for protection and by shooting spikes to repel foes.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Crustabri",
+                "german": "Austos"
+            }
         },
         {
             "id": 92,
@@ -2812,7 +3176,11 @@
                 "Gengar"
             ],
             "description": "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Fantominus",
+                "german": "Nebulak"
+            }
         },
         {
             "id": 93,
@@ -2842,7 +3210,11 @@
                 "Gengar"
             ],
             "description": "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Spectrum",
+                "german": "Alpollo"
+            }
         },
         {
             "id": 94,
@@ -2872,7 +3244,11 @@
                 "Gengar"
             ],
             "description": "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ectoplasma",
+                "german": "Gengar"
+            }
         },
         {
             "id": 95,
@@ -2902,7 +3278,11 @@
                 "Onix"
             ],
             "description": "Opening its large mouth, it ingests massive amounts of soil and creates long tunnels.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Onix",
+                "german": "Onix"
+            }
         },
         {
             "id": 96,
@@ -2932,7 +3312,11 @@
                 "Hypno"
             ],
             "description": "It can tell what people are dreaming by sniffing with its big nose. It loves fun dreams.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Soporifik",
+                "german": "Traumato"
+            }
         },
         {
             "id": 97,
@@ -2962,7 +3346,11 @@
                 "Hypno"
             ],
             "description": "Seeing its swinging pendulum can induce sleep in three seconds, even in someone who just woke up.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Hypnomade",
+                "german": "Hypno"
+            }
         },
         {
             "id": 98,
@@ -2992,7 +3380,11 @@
                 "Kingler"
             ],
             "description": "It lives in burrows dug on sandy beaches. Its pincers fully grow back if they are broken in battle.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Krabby",
+                "german": "Krabby"
+            }
         },
         {
             "id": 99,
@@ -3022,7 +3414,11 @@
                 "Kingler"
             ],
             "description": "The larger pincer has 10,000- horsepower strength. However, it is so heavy, it is difficult to aim.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Krabboss",
+                "german": "Kingler"
+            }
         },
         {
             "id": 100,
@@ -3052,7 +3448,11 @@
                 "Electrode"
             ],
             "description": "It looks just like a Pok Ball. It is dangerous because it may electrocute or explode on contact.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Voltorbe",
+                "german": "Voltobal"
+            }
         },
         {
             "id": 101,
@@ -3082,7 +3482,11 @@
                 "Electrode"
             ],
             "description": "It is known to drift on winds if it is bloated to bursting with stored electricity.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "\u00c9lectrode",
+                "german": "Lektrobal"
+            }
         },
         {
             "id": 102,
@@ -3112,7 +3516,11 @@
                 "Exeggutor"
             ],
             "description": "Its six eggs converse using telepathy. They can quickly gather if they become separated.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "N\u0153un\u0153uf",
+                "german": "Owei"
+            }
         },
         {
             "id": 103,
@@ -3142,7 +3550,11 @@
                 "Exeggutor"
             ],
             "description": "It is called The Walking Jungle. If a head grows too big, it falls off and becomes an Exeggcute.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Noadkoko",
+                "german": "Kokowei"
+            }
         },
         {
             "id": 104,
@@ -3172,7 +3584,11 @@
                 "Marowak"
             ],
             "description": "When it thinks of its dead mother, it cries. Its crying makes the skull it wears rattle hollowly.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Osselait",
+                "german": "Tragosso"
+            }
         },
         {
             "id": 105,
@@ -3202,7 +3618,11 @@
                 "Marowak"
             ],
             "description": "From its birth, this savage Pokemon constantly holds bones. It is skilled in using them as weapons.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ossatueur",
+                "german": "Knogga"
+            }
         },
         {
             "id": 106,
@@ -3232,7 +3652,11 @@
                 "Hitmonchan"
             ],
             "description": "Its legs can stretch double. First-time foes are startled by its extensible reach.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kicklee",
+                "german": "Kicklee"
+            }
         },
         {
             "id": 107,
@@ -3262,7 +3686,11 @@
                 "Hitmonchan"
             ],
             "description": "The arm-twisting punches it throws pulverize even concrete. It rests after three minutes of fighting.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tygnon",
+                "german": "Nockchan"
+            }
         },
         {
             "id": 108,
@@ -3291,7 +3719,11 @@
                 "Lickitung"
             ],
             "description": "Being licked by its long, saliva-covered tongue leaves a tingling sensation. Extending its tongue retracts its tail.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Excelangue",
+                "german": "Schlurp"
+            }
         },
         {
             "id": 109,
@@ -3319,7 +3751,11 @@
                 "Weezing"
             ],
             "description": "Toxic gas is held within its thin, balloon-shaped body, so it can cause massive explosions.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Smogo",
+                "german": "Smogon"
+            }
         },
         {
             "id": 110,
@@ -3347,7 +3783,11 @@
                 "Weezing"
             ],
             "description": "Inhaling toxic fumes from trash and mixing them inside its body lets it spread an even fouler stench.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Smogogo",
+                "german": "Smogmog"
+            }
         },
         {
             "id": 111,
@@ -3378,7 +3818,11 @@
                 "Rhydon"
             ],
             "description": "Its powerful tackles can destroy anything. However, it is too slow witted to help people work.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rhinocorne",
+                "german": "Rihorn"
+            }
         },
         {
             "id": 112,
@@ -3409,7 +3853,11 @@
                 "Rhydon"
             ],
             "description": "Standing on its hind legs freed its forelegs and made it smarter. It is very forgetful, however.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Rhinof\u00e9ros",
+                "german": "Rizeros"
+            }
         },
         {
             "id": 113,
@@ -3438,7 +3886,11 @@
                 "Chansey"
             ],
             "description": "A kindly Pokemon that lays highly nutritious eggs and shares them with injured Pokmon or people.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Leveinard",
+                "german": "Chaneira"
+            }
         },
         {
             "id": 114,
@@ -3467,7 +3919,11 @@
                 "Tangela"
             ],
             "description": "Many writhing vines cover it, so its true identity remains unknown. The blue vines grow its whole life long.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Saquedeneu",
+                "german": "Tangela"
+            }
         },
         {
             "id": 115,
@@ -3494,7 +3950,11 @@
             },
             "evolution": [],
             "description": "It raises its offspring in its belly pouch. It lets the baby out to play only when it feels safe.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kangourex",
+                "german": "Kangama"
+            }
         },
         {
             "id": 116,
@@ -3524,7 +3984,11 @@
                 "Seadra"
             ],
             "description": "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Hypotrempe",
+                "german": "Seeper"
+            }
         },
         {
             "id": 117,
@@ -3554,7 +4018,11 @@
                 "Seadra"
             ],
             "description": "Its spines provide protection. Its fins and bones are prized as traditional-medicine ingredients.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Hypoc\u00e9an",
+                "german": "Seemon"
+            }
         },
         {
             "id": 118,
@@ -3584,7 +4052,11 @@
                 "Seaking"
             ],
             "description": "Though it appears very elegant when swimming with fins unfurled, it can jab powerfully with its horn.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Poissir\u00e8ne",
+                "german": "Goldini"
+            }
         },
         {
             "id": 119,
@@ -3614,7 +4086,11 @@
                 "Seaking"
             ],
             "description": "In autumn, its body becomes more fatty in preparing to propose to a mate. It takes on beautiful colors.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Poissoroy",
+                "german": "Golking"
+            }
         },
         {
             "id": 120,
@@ -3644,7 +4120,11 @@
                 "Starmie"
             ],
             "description": "As long as its red core remains, it can regenerate its body instantly, even if its torn apart.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Stari",
+                "german": "Sterndu"
+            }
         },
         {
             "id": 121,
@@ -3675,7 +4155,11 @@
                 "Starmie"
             ],
             "description": "Its core shines in many colors and sends radio signals into space to communicate with something.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Staross",
+                "german": "Starmie"
+            }
         },
         {
             "id": 122,
@@ -3705,7 +4189,11 @@
                 "Mr. Mime"
             ],
             "description": "It shapes an invisible wall in midair by minutely vibrating its fingertips to stop molecules in the air.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "M. Mime",
+                "german": "Pantimos"
+            }
         },
         {
             "id": 123,
@@ -3735,7 +4223,11 @@
                 "Scyther"
             ],
             "description": "The sharp scythes on its forearms become increasingly sharp by cutting through hard objects.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Ins\u00e9cateur",
+                "german": "Sichlor"
+            }
         },
         {
             "id": 124,
@@ -3765,7 +4257,11 @@
                 "Jynx"
             ],
             "description": "Its cries sound like human speech. However, it is impossible to tell what it is trying to say.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Lippoutou",
+                "german": "Rossana"
+            }
         },
         {
             "id": 125,
@@ -3793,7 +4289,11 @@
                 "Electabuzz"
             ],
             "description": "Research is progressing on storing lightning in Electabuzz so this energy can be used at any time.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "\u00c9lektek",
+                "german": "Elektek"
+            }
         },
         {
             "id": 126,
@@ -3821,7 +4321,11 @@
                 "Magmar"
             ],
             "description": "The scorching fire exhaled by Magmar forms heat waves around its body, making it hard to see the Pokemon clearly.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Magmar",
+                "german": "Magmar"
+            }
         },
         {
             "id": 127,
@@ -3848,7 +4352,11 @@
             },
             "evolution": [],
             "description": "It grips prey with its powerful pincers and will not let go until the prey is torn in half.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Scarabrute",
+                "german": "Pinsir"
+            }
         },
         {
             "id": 128,
@@ -3875,7 +4383,11 @@
             },
             "evolution": [],
             "description": "Once it takes aim at its foe, it makes a headlong charge. It is famous for its violent nature.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Tauros",
+                "german": "Tauros"
+            }
         },
         {
             "id": 129,
@@ -3904,7 +4416,11 @@
                 "Gyarados"
             ],
             "description": "A Magikarp living for many years can leap a mountain using Splash. The move remains useless, though.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Magicarpe",
+                "german": "Karpador"
+            }
         },
         {
             "id": 130,
@@ -3934,7 +4450,11 @@
                 "Gyarados"
             ],
             "description": "Once it begins to rampage, a Gyarados will burn everything down, even in a harsh storm.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "L\u00e9viator",
+                "german": "Garados"
+            }
         },
         {
             "id": 131,
@@ -3962,7 +4482,11 @@
             },
             "evolution": [],
             "description": "Able to understand human speech and very intelligent, it loves to swim in the sea with people on its back.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Lokhlass",
+                "german": "Lapras"
+            }
         },
         {
             "id": 132,
@@ -3988,7 +4512,11 @@
             },
             "evolution": [],
             "description": "It can reconstitute its entire cellular structure to change into what it sees, but it returns to normal when it relaxes.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "M\u00e9tamorph",
+                "german": "Ditto"
+            }
         },
         {
             "id": 133,
@@ -4020,7 +4548,11 @@
                 "Eevee"
             ],
             "description": "Thanks to its unstable genetic makeup, this special Pokemon conceals many different possible evolutions.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "\u00c9voli",
+                "german": "Evoli"
+            }
         },
         {
             "id": 134,
@@ -4051,7 +4583,11 @@
                 "Eevee"
             ],
             "description": "Its cell composition is similar to water molecules. As a result, it cant be seen when it melts away into water.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Aquali",
+                "german": "Aquana"
+            }
         },
         {
             "id": 135,
@@ -4082,7 +4618,11 @@
                 "Eevee"
             ],
             "description": "By storing electricity in its body, it can shoot its bristlelike fur like a barrage of missiles.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Voltali",
+                "german": "Blitza"
+            }
         },
         {
             "id": 136,
@@ -4113,7 +4653,11 @@
                 "Eevee"
             ],
             "description": "Inhaled air is carried to its flame sac, heated, and exhaled as fire that reaches over 3,000 degrees F.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Pyroli",
+                "german": "Flamara"
+            }
         },
         {
             "id": 137,
@@ -4142,7 +4686,11 @@
                 "Porygon"
             ],
             "description": "A man-made Pokemon created using advanced scientific means. It can move freely in cyberspace.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Porygon",
+                "german": "Porygon"
+            }
         },
         {
             "id": 138,
@@ -4173,7 +4721,11 @@
                 "Omastar"
             ],
             "description": "A Pokemon that was resurrected from a fossil using modern science. It swam in ancient seas.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Amonita",
+                "german": "Amonitas"
+            }
         },
         {
             "id": 139,
@@ -4204,7 +4756,11 @@
                 "Omastar"
             ],
             "description": "It is thought that this Pokemon became extinct because its spiral shell grew too large.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Amonistar",
+                "german": "Amoroso"
+            }
         },
         {
             "id": 140,
@@ -4235,7 +4791,11 @@
                 "Kabutops"
             ],
             "description": "It is thought to have inhabited beaches 300 million years ago. It is protected by a stiff shell.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kabuto",
+                "german": "Kabuto"
+            }
         },
         {
             "id": 141,
@@ -4266,7 +4826,11 @@
                 "Kabutops"
             ],
             "description": "It is thought that this Pokemon came onto land because its prey adapted to life on land.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Kabutops",
+                "german": "Kabutops"
+            }
         },
         {
             "id": 142,
@@ -4294,15 +4858,18 @@
             },
             "evolution": [],
             "description": "A Pokemon that roamed the skies in the dinosaur era. Its teeth are like saw blades.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Pt\u00e9ra",
+                "german": "Aerodactyl"
+            }
         },
         {
             "id": 143,
             "name": "Snorlax",
             "name_language": {
                 "french": "Ronflex",
-                "german": "Relaxo",
-                "spanish": "Snorlax"
+                "german": "Relaxo"
             },
             "species": "Sleeping Pokemon",
             "type": [
@@ -4355,7 +4922,11 @@
             },
             "evolution": [],
             "description": "A legendary bird Pokemon. It can create blizzards by freezing moisture in the air.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Artikodin",
+                "german": "Arktos"
+            }
         },
         {
             "id": 145,
@@ -4382,7 +4953,11 @@
             },
             "evolution": [],
             "description": "A legendary Pokemon that is said to live in thunderclouds. It freely controls lightning bolts.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "\u00c9lecthor",
+                "german": "Zapdos"
+            }
         },
         {
             "id": 146,
@@ -4409,7 +4984,11 @@
             },
             "evolution": [],
             "description": "One of the legendary bird Pokemon. It is said that its appearance indicates the coming of spring.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Sulfura",
+                "german": "Lavados"
+            }
         },
         {
             "id": 147,
@@ -4439,7 +5018,11 @@
                 "Dragonite"
             ],
             "description": "It is called the Mirage Pokemon because so few have seen it. Its shed skin has been found.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Minidraco",
+                "german": "Dratini"
+            }
         },
         {
             "id": 148,
@@ -4469,7 +5052,11 @@
                 "Dragonite"
             ],
             "description": "If its body takes on an aura, the weather changes instantly. It is said to live in seas and lakes.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Draco",
+                "german": "Dragonir"
+            }
         },
         {
             "id": 149,
@@ -4500,7 +5087,11 @@
                 "Dragonite"
             ],
             "description": "It is said to make its home somewhere in the sea. It guides crews of shipwrecks to shore.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Dracolosse",
+                "german": "Dragoran"
+            }
         },
         {
             "id": 150,
@@ -4526,7 +5117,11 @@
             },
             "evolution": [],
             "description": "A Pokemon created by recombining Mews genes. Its said to have the most savage heart among Pokmon.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Mewtwo",
+                "german": "Mewtu"
+            }
         },
         {
             "id": 151,
@@ -4551,7 +5146,11 @@
             },
             "evolution": [],
             "description": "Mew is said to possess the genetic composition of all Pokemon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.",
-            "gen": 1
+            "gen": 1,
+            "name_language": {
+                "french": "Mew",
+                "german": "Mew"
+            }
         },
         {
             "name": "Chikorita",
@@ -4577,7 +5176,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Germignon",
+                "german": "Endivie"
+            }
         },
         {
             "name": "Bayleef",
@@ -4603,7 +5206,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Macronium",
+                "german": "Lorblatt"
+            }
         },
         {
             "name": "Meganium",
@@ -4629,7 +5236,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "M\u00e9ganium",
+                "german": "Meganie"
+            }
         },
         {
             "name": "Cyndaquil",
@@ -4655,7 +5266,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "H\u00e9ricendre",
+                "german": "Feurigel"
+            }
         },
         {
             "name": "Quilava",
@@ -4681,7 +5296,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Feurisson",
+                "german": "Igelavar"
+            }
         },
         {
             "name": "Typhlosion",
@@ -4707,7 +5326,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Typhlosion",
+                "german": "Tornupto"
+            }
         },
         {
             "name": "Totodile",
@@ -4733,7 +5356,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Kaiminus",
+                "german": "Karnimani"
+            }
         },
         {
             "name": "Croconaw",
@@ -4759,7 +5386,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Crocrodil",
+                "german": "Tyracroc"
+            }
         },
         {
             "name": "Feraligatr",
@@ -4785,7 +5416,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Aligatueur",
+                "german": "Impergator"
+            }
         },
         {
             "name": "Sentret",
@@ -4812,7 +5447,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Fouinette",
+                "german": "Wiesor"
+            }
         },
         {
             "name": "Furret",
@@ -4839,7 +5478,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Fouinar",
+                "german": "Wiesenior"
+            }
         },
         {
             "name": "Hoothoot",
@@ -4867,7 +5510,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Hoothoot",
+                "german": "Hoothoot"
+            }
         },
         {
             "name": "Noctowl",
@@ -4895,7 +5542,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Noarfang",
+                "german": "Noctuh"
+            }
         },
         {
             "name": "Ledyba",
@@ -4923,7 +5574,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Coxy",
+                "german": "Ledyba"
+            }
         },
         {
             "name": "Ledian",
@@ -4951,7 +5606,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Coxyclaque",
+                "german": "Ledian"
+            }
         },
         {
             "name": "Spinarak",
@@ -4979,7 +5638,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Mimigal",
+                "german": "Webarak"
+            }
         },
         {
             "name": "Ariados",
@@ -5007,7 +5670,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Migalos",
+                "german": "Ariados"
+            }
         },
         {
             "name": "Crobat",
@@ -5034,7 +5701,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Nostenfer",
+                "german": "Iksbat"
+            }
         },
         {
             "name": "Chinchou",
@@ -5062,7 +5733,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Loupio",
+                "german": "Lampi"
+            }
         },
         {
             "name": "Lanturn",
@@ -5090,7 +5765,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Lanturn",
+                "german": "Lanturn"
+            }
         },
         {
             "name": "Pichu",
@@ -5116,7 +5795,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Pichu",
+                "german": "Pichu"
+            }
         },
         {
             "name": "Cleffa",
@@ -5143,7 +5826,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "M\u00e9lo",
+                "german": "Pii"
+            }
         },
         {
             "name": "Igglybuff",
@@ -5171,7 +5858,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Toudoudou",
+                "german": "Fluffeluff"
+            }
         },
         {
             "name": "Togepi",
@@ -5198,7 +5889,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Togepi",
+                "german": "Togepi"
+            }
         },
         {
             "name": "Togetic",
@@ -5226,7 +5921,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Togetic",
+                "german": "Togetic"
+            }
         },
         {
             "name": "Natu",
@@ -5254,7 +5953,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Natu",
+                "german": "Natu"
+            }
         },
         {
             "name": "Xatu",
@@ -5282,7 +5985,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Xatu",
+                "german": "Xatu"
+            }
         },
         {
             "name": "Mareep",
@@ -5308,7 +6015,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Wattouat",
+                "german": "Voltilamm"
+            }
         },
         {
             "name": "Flaaffy",
@@ -5334,7 +6045,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Lainergie",
+                "german": "Waaty"
+            }
         },
         {
             "name": "Ampharos",
@@ -5360,7 +6075,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Pharamp",
+                "german": "Ampharos"
+            }
         },
         {
             "name": "Bellossom",
@@ -5386,7 +6105,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Joliflor",
+                "german": "Blubella"
+            }
         },
         {
             "name": "Marill",
@@ -5414,7 +6137,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Marill",
+                "german": "Marill"
+            }
         },
         {
             "name": "Azumarill",
@@ -5442,7 +6169,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Azumarill",
+                "german": "Azumarill"
+            }
         },
         {
             "name": "Sudowoodo",
@@ -5469,7 +6200,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Simularbre",
+                "german": "Mogelbaum"
+            }
         },
         {
             "name": "Politoed",
@@ -5496,7 +6231,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Tarpaud",
+                "german": "Quaxo"
+            }
         },
         {
             "name": "Hoppip",
@@ -5524,7 +6263,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Granivol",
+                "german": "Hoppspross"
+            }
         },
         {
             "name": "Skiploom",
@@ -5552,7 +6295,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Floravol",
+                "german": "Hubelupf"
+            }
         },
         {
             "name": "Jumpluff",
@@ -5580,7 +6327,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Cotovol",
+                "german": "Papungha"
+            }
         },
         {
             "name": "Aipom",
@@ -5607,7 +6358,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Capumain",
+                "german": "Griffel"
+            }
         },
         {
             "name": "Sunkern",
@@ -5634,7 +6389,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Tournegrin",
+                "german": "Sonnkern"
+            }
         },
         {
             "name": "Sunflora",
@@ -5661,7 +6420,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "H\u00e9liatronc",
+                "german": "Sonnflora"
+            }
         },
         {
             "name": "Yanma",
@@ -5689,7 +6452,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Yanma",
+                "german": "Yanma"
+            }
         },
         {
             "name": "Wooper",
@@ -5717,7 +6484,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Axoloto",
+                "german": "Felino"
+            }
         },
         {
             "name": "Quagsire",
@@ -5745,7 +6516,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Maraiste",
+                "german": "Morlord"
+            }
         },
         {
             "name": "Espeon",
@@ -5771,7 +6546,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Mentali",
+                "german": "Psiana"
+            }
         },
         {
             "name": "Umbreon",
@@ -5797,7 +6576,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Noctali",
+                "german": "Nachtara"
+            }
         },
         {
             "name": "Murkrow",
@@ -5825,7 +6608,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Corn\u00e8bre",
+                "german": "Kramurx"
+            }
         },
         {
             "name": "Slowking",
@@ -5853,7 +6640,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Roigada",
+                "german": "Laschoking"
+            }
         },
         {
             "name": "Misdreavus",
@@ -5878,7 +6669,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Feufor\u00eave",
+                "german": "Traunfugil"
+            }
         },
         {
             "name": "Unown",
@@ -5903,7 +6698,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Zarbi",
+                "german": "Icognito"
+            }
         },
         {
             "name": "Wobbuffet",
@@ -5929,7 +6728,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Qulbutok\u00e9",
+                "german": "Woingenau"
+            }
         },
         {
             "name": "Girafarig",
@@ -5957,7 +6760,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Girafarig",
+                "german": "Girafarig"
+            }
         },
         {
             "name": "Pineco",
@@ -5983,7 +6790,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Pomdepic",
+                "german": "Tannza"
+            }
         },
         {
             "name": "Forretress",
@@ -6010,7 +6821,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Foretress",
+                "german": "Forstellka"
+            }
         },
         {
             "name": "Dunsparce",
@@ -6037,7 +6852,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Insolourdo",
+                "german": "Dummisel"
+            }
         },
         {
             "name": "Gligar",
@@ -6065,7 +6884,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Scorplane",
+                "german": "Skorgla"
+            }
         },
         {
             "name": "Steelix",
@@ -6093,7 +6916,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Steelix",
+                "german": "Stahlos"
+            }
         },
         {
             "name": "Snubbull",
@@ -6120,7 +6947,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Snubbull",
+                "german": "Snubbull"
+            }
         },
         {
             "name": "Granbull",
@@ -6147,7 +6978,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Granbull",
+                "german": "Granbull"
+            }
         },
         {
             "name": "Qwilfish",
@@ -6175,7 +7010,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Qwilfish",
+                "german": "Baldorfish"
+            }
         },
         {
             "name": "Scizor",
@@ -6203,7 +7042,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Cizayox",
+                "german": "Scherox"
+            }
         },
         {
             "name": "Shuckle",
@@ -6231,7 +7074,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Caratroc",
+                "german": "Pottrott"
+            }
         },
         {
             "name": "Heracross",
@@ -6259,7 +7106,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Scarhino",
+                "german": "Skaraborn"
+            }
         },
         {
             "name": "Sneasel",
@@ -6287,7 +7138,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Farfuret",
+                "german": "Sniebel"
+            }
         },
         {
             "name": "Teddiursa",
@@ -6314,7 +7169,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Teddiursa",
+                "german": "Teddiursa"
+            }
         },
         {
             "name": "Ursaring",
@@ -6341,7 +7200,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Ursaring",
+                "german": "Ursaring"
+            }
         },
         {
             "name": "Slugma",
@@ -6368,7 +7231,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Limagma",
+                "german": "Schneckmag"
+            }
         },
         {
             "name": "Magcargo",
@@ -6396,7 +7263,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Volcaropod",
+                "german": "Magcargo"
+            }
         },
         {
             "name": "Swinub",
@@ -6424,7 +7295,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Marcacrin",
+                "german": "Quiekel"
+            }
         },
         {
             "name": "Piloswine",
@@ -6452,7 +7327,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Cochignon",
+                "german": "Keifel"
+            }
         },
         {
             "name": "Corsola",
@@ -6480,7 +7359,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Corayon",
+                "german": "Corasonn"
+            }
         },
         {
             "name": "Remoraid",
@@ -6507,7 +7390,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "R\u00e9moraid",
+                "german": "Remoraid"
+            }
         },
         {
             "name": "Octillery",
@@ -6534,7 +7421,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Octillery",
+                "german": "Octillery"
+            }
         },
         {
             "name": "Delibird",
@@ -6562,7 +7453,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Cadoizo",
+                "german": "Botogel"
+            }
         },
         {
             "name": "Mantine",
@@ -6590,7 +7485,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "D\u00e9manta",
+                "german": "Mantax"
+            }
         },
         {
             "name": "Skarmory",
@@ -6618,7 +7517,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Airmure",
+                "german": "Panzaeron"
+            }
         },
         {
             "name": "Houndour",
@@ -6646,7 +7549,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Malosse",
+                "german": "Hunduster"
+            }
         },
         {
             "name": "Houndoom",
@@ -6674,7 +7581,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "D\u00e9molosse",
+                "german": "Hundemon"
+            }
         },
         {
             "name": "Kingdra",
@@ -6702,7 +7613,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Hyporoi",
+                "german": "Seedraking"
+            }
         },
         {
             "name": "Phanpy",
@@ -6728,7 +7643,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Phanpy",
+                "german": "Phanpy"
+            }
         },
         {
             "name": "Donphan",
@@ -6754,7 +7673,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Donphan",
+                "german": "Donphan"
+            }
         },
         {
             "name": "Porygon2",
@@ -6781,7 +7704,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Porygon2",
+                "german": "Porygon2"
+            }
         },
         {
             "name": "Stantler",
@@ -6808,7 +7735,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Cerfrousse",
+                "german": "Damhirplex"
+            }
         },
         {
             "name": "Smeargle",
@@ -6835,7 +7766,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Queulorior",
+                "german": "Farbeagle"
+            }
         },
         {
             "name": "Tyrogue",
@@ -6862,7 +7797,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Debugant",
+                "german": "Rabauz"
+            }
         },
         {
             "name": "Hitmontop",
@@ -6889,7 +7828,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Kapoera",
+                "german": "Kapoera"
+            }
         },
         {
             "name": "Smoochum",
@@ -6917,7 +7860,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Lippouti",
+                "german": "Kussilla"
+            }
         },
         {
             "name": "Elekid",
@@ -6943,7 +7890,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "\u00c9lekid",
+                "german": "Elekid"
+            }
         },
         {
             "name": "Magby",
@@ -6969,7 +7920,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Magby",
+                "german": "Magby"
+            }
         },
         {
             "name": "Miltank",
@@ -6996,7 +7951,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "\u00c9cr\u00e9meuh",
+                "german": "Miltank"
+            }
         },
         {
             "name": "Blissey",
@@ -7023,7 +7982,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Leuphorie",
+                "german": "Heiteira"
+            }
         },
         {
             "name": "Raikou",
@@ -7049,7 +8012,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Raikou",
+                "german": "Raikou"
+            }
         },
         {
             "name": "Entei",
@@ -7075,7 +8042,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Entei",
+                "german": "Entei"
+            }
         },
         {
             "name": "Suicune",
@@ -7101,7 +8072,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Suicune",
+                "german": "Suicune"
+            }
         },
         {
             "name": "Larvitar",
@@ -7128,7 +8103,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Embrylex",
+                "german": "Larvitar"
+            }
         },
         {
             "name": "Pupitar",
@@ -7154,7 +8133,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Ymphect",
+                "german": "Pupitar"
+            }
         },
         {
             "name": "Tyranitar",
@@ -7181,7 +8164,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Tyranocif",
+                "german": "Despotar"
+            }
         },
         {
             "name": "Lugia",
@@ -7208,7 +8195,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Lugia",
+                "german": "Lugia"
+            }
         },
         {
             "name": "Ho-Oh",
@@ -7235,7 +8226,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Ho-Oh",
+                "german": "Ho-Oh"
+            }
         },
         {
             "name": "Celebi",
@@ -7261,7 +8256,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 2
+            "gen": 2,
+            "name_language": {
+                "french": "Celebi",
+                "german": "Celebi"
+            }
         },
         {
             "name": "Treecko",
@@ -7287,7 +8286,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Arcko",
+                "german": "Geckarbor"
+            }
         },
         {
             "name": "Grovyle",
@@ -7313,7 +8316,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Massko",
+                "german": "Reptain"
+            }
         },
         {
             "name": "Sceptile",
@@ -7339,7 +8346,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Jungko",
+                "german": "Gewaldro"
+            }
         },
         {
             "name": "Torchic",
@@ -7365,7 +8376,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Poussifeu",
+                "german": "Flemmli"
+            }
         },
         {
             "name": "Combusken",
@@ -7392,7 +8407,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Galifeu",
+                "german": "Jungglut"
+            }
         },
         {
             "name": "Blaziken",
@@ -7419,7 +8438,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Bras\u00e9gali",
+                "german": "Lohgock"
+            }
         },
         {
             "name": "Mudkip",
@@ -7445,7 +8468,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Gobou",
+                "german": "Hydropi"
+            }
         },
         {
             "name": "Marshtomp",
@@ -7472,7 +8499,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Flobio",
+                "german": "Moorabbel"
+            }
         },
         {
             "name": "Swampert",
@@ -7499,7 +8530,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Laggron",
+                "german": "Sumpex"
+            }
         },
         {
             "name": "Poochyena",
@@ -7526,7 +8561,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Medhy\u00e8na",
+                "german": "Fiffyen"
+            }
         },
         {
             "name": "Mightyena",
@@ -7553,7 +8592,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Grahy\u00e8na",
+                "german": "Magnayen"
+            }
         },
         {
             "name": "Zigzagoon",
@@ -7580,7 +8623,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Zigzaton",
+                "german": "Zigzachs"
+            }
         },
         {
             "name": "Linoone",
@@ -7607,7 +8654,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lin\u00e9on",
+                "german": "Geradaks"
+            }
         },
         {
             "name": "Wurmple",
@@ -7633,7 +8684,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Chenipotte",
+                "german": "Waumpel"
+            }
         },
         {
             "name": "Silcoon",
@@ -7658,7 +8713,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Armulys",
+                "german": "Schaloko"
+            }
         },
         {
             "name": "Beautifly",
@@ -7685,7 +8744,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Charmillon",
+                "german": "Papinella"
+            }
         },
         {
             "name": "Cascoon",
@@ -7710,7 +8773,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Blindalys",
+                "german": "Panekon"
+            }
         },
         {
             "name": "Dustox",
@@ -7737,7 +8804,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Papinox",
+                "german": "Pudox"
+            }
         },
         {
             "name": "Lotad",
@@ -7765,7 +8836,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "N\u00e9nupiot",
+                "german": "Loturzel"
+            }
         },
         {
             "name": "Lombre",
@@ -7793,7 +8868,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lombre",
+                "german": "Lombrero"
+            }
         },
         {
             "name": "Ludicolo",
@@ -7821,7 +8900,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ludicolo",
+                "german": "Kappalores"
+            }
         },
         {
             "name": "Seedot",
@@ -7848,7 +8931,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Grainipiot",
+                "german": "Samurzel"
+            }
         },
         {
             "name": "Nuzleaf",
@@ -7876,7 +8963,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Pifeuil",
+                "german": "Blanas"
+            }
         },
         {
             "name": "Shiftry",
@@ -7904,7 +8995,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Tengalice",
+                "german": "Tengulist"
+            }
         },
         {
             "name": "Taillow",
@@ -7931,7 +9026,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Nirondelle",
+                "german": "Schwalbini"
+            }
         },
         {
             "name": "Swellow",
@@ -7958,7 +9057,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "H\u00e9l\u00e9delle",
+                "german": "Schwalboss"
+            }
         },
         {
             "name": "Wingull",
@@ -7986,7 +9089,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Go\u00e9lise",
+                "german": "Wingull"
+            }
         },
         {
             "name": "Pelipper",
@@ -8014,7 +9121,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Bekipan",
+                "german": "Pelipper"
+            }
         },
         {
             "name": "Ralts",
@@ -8042,7 +9153,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Tarsal",
+                "german": "Trasla"
+            }
         },
         {
             "name": "Kirlia",
@@ -8070,7 +9185,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kirlia",
+                "german": "Kirlia"
+            }
         },
         {
             "name": "Gardevoir",
@@ -8098,7 +9217,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Gardevoir",
+                "german": "Guardevoir"
+            }
         },
         {
             "name": "Surskit",
@@ -8125,7 +9248,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Arakdo",
+                "german": "Gehweiher"
+            }
         },
         {
             "name": "Masquerain",
@@ -8152,7 +9279,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Maskadra",
+                "german": "Maskeregen"
+            }
         },
         {
             "name": "Shroomish",
@@ -8179,7 +9310,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Balignon",
+                "german": "Knilz"
+            }
         },
         {
             "name": "Breloom",
@@ -8207,7 +9342,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Chapignon",
+                "german": "Kapilz"
+            }
         },
         {
             "name": "Slakoth",
@@ -8232,7 +9371,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Parecool",
+                "german": "Bummelz"
+            }
         },
         {
             "name": "Vigoroth",
@@ -8257,7 +9400,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Vigoroth",
+                "german": "Muntier"
+            }
         },
         {
             "name": "Slaking",
@@ -8282,7 +9429,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Monafl\u00e8mit",
+                "german": "Letarking"
+            }
         },
         {
             "name": "Nincada",
@@ -8309,7 +9460,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ningale",
+                "german": "Nincada"
+            }
         },
         {
             "name": "Ninjask",
@@ -8336,7 +9491,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ninjask",
+                "german": "Ninjask"
+            }
         },
         {
             "name": "Shedinja",
@@ -8362,7 +9521,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Munja",
+                "german": "Ninjatom"
+            }
         },
         {
             "name": "Whismur",
@@ -8388,7 +9551,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Chuchmur",
+                "german": "Flurmel"
+            }
         },
         {
             "name": "Loudred",
@@ -8414,7 +9581,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ramboum",
+                "german": "Krakeelo"
+            }
         },
         {
             "name": "Exploud",
@@ -8440,7 +9611,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Brouhabam",
+                "german": "Krawumms"
+            }
         },
         {
             "name": "Makuhita",
@@ -8467,7 +9642,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Makuhita",
+                "german": "Makuhita"
+            }
         },
         {
             "name": "Hariyama",
@@ -8494,7 +9673,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Hariyama",
+                "german": "Hariyama"
+            }
         },
         {
             "name": "Azurill",
@@ -8522,7 +9705,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Azurill",
+                "german": "Azurill"
+            }
         },
         {
             "name": "Nosepass",
@@ -8549,7 +9736,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Tarinor",
+                "german": "Nasgnet"
+            }
         },
         {
             "name": "Skitty",
@@ -8576,7 +9767,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Skitty",
+                "german": "Eneco"
+            }
         },
         {
             "name": "Delcatty",
@@ -8603,7 +9798,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Delcatty",
+                "german": "Enekoro"
+            }
         },
         {
             "name": "Sableye",
@@ -8631,7 +9830,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "T\u00e9n\u00e9fix",
+                "german": "Zobiris"
+            }
         },
         {
             "name": "Mawile",
@@ -8659,7 +9862,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Mysdibule",
+                "german": "Flunkifer"
+            }
         },
         {
             "name": "Aron",
@@ -8687,7 +9894,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Galekid",
+                "german": "Stollunior"
+            }
         },
         {
             "name": "Lairon",
@@ -8715,7 +9926,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Galegon",
+                "german": "Stollrak"
+            }
         },
         {
             "name": "Aggron",
@@ -8743,7 +9958,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Galeking",
+                "german": "Stolloss"
+            }
         },
         {
             "name": "Meditite",
@@ -8770,7 +9989,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "M\u00e9ditikka",
+                "german": "Meditie"
+            }
         },
         {
             "name": "Medicham",
@@ -8797,7 +10020,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Charmina",
+                "german": "Meditalis"
+            }
         },
         {
             "name": "Electrike",
@@ -8824,7 +10051,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Dynavolt",
+                "german": "Frizelbliz"
+            }
         },
         {
             "name": "Manectric",
@@ -8851,7 +10082,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "\u00c9lecsprint",
+                "german": "Voltenso"
+            }
         },
         {
             "name": "Plusle",
@@ -8877,7 +10112,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Posipi",
+                "german": "Plusle"
+            }
         },
         {
             "name": "Minun",
@@ -8903,7 +10142,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "N\u00e9gapi",
+                "german": "Minun"
+            }
         },
         {
             "name": "Volbeat",
@@ -8930,7 +10173,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Muciole",
+                "german": "Volbeat"
+            }
         },
         {
             "name": "Illumise",
@@ -8957,7 +10204,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lumivole",
+                "german": "Illumise"
+            }
         },
         {
             "name": "Roselia",
@@ -8985,7 +10236,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ros\u00e9lia",
+                "german": "Roselia"
+            }
         },
         {
             "name": "Gulpin",
@@ -9012,7 +10267,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Gloupti",
+                "german": "Schluppuck"
+            }
         },
         {
             "name": "Swalot",
@@ -9039,7 +10298,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Avaltout",
+                "german": "Schlukwech"
+            }
         },
         {
             "name": "Carvanha",
@@ -9066,7 +10329,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Carvanha",
+                "german": "Kanivanha"
+            }
         },
         {
             "name": "Sharpedo",
@@ -9093,7 +10360,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Sharpedo",
+                "german": "Tohaido"
+            }
         },
         {
             "name": "Wailmer",
@@ -9120,7 +10391,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Wailmer",
+                "german": "Wailmer"
+            }
         },
         {
             "name": "Wailord",
@@ -9147,7 +10422,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Wailord",
+                "german": "Wailord"
+            }
         },
         {
             "name": "Numel",
@@ -9175,7 +10454,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Chamallot",
+                "german": "Camaub"
+            }
         },
         {
             "name": "Camerupt",
@@ -9203,7 +10486,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Cam\u00e9rupt",
+                "german": "Camerupt"
+            }
         },
         {
             "name": "Torkoal",
@@ -9230,7 +10517,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Chartor",
+                "german": "Qurtel"
+            }
         },
         {
             "name": "Spoink",
@@ -9257,7 +10548,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Spoink",
+                "german": "Spoink"
+            }
         },
         {
             "name": "Grumpig",
@@ -9284,7 +10579,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Groret",
+                "german": "Groink"
+            }
         },
         {
             "name": "Spinda",
@@ -9311,7 +10610,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Spinda",
+                "german": "Pandir"
+            }
         },
         {
             "name": "Trapinch",
@@ -9338,7 +10641,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kraknoix",
+                "german": "Knacklion"
+            }
         },
         {
             "name": "Vibrava",
@@ -9364,7 +10671,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Vibraninf",
+                "german": "Vibrava"
+            }
         },
         {
             "name": "Flygon",
@@ -9390,7 +10701,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lib\u00e9gon",
+                "german": "Libelldra"
+            }
         },
         {
             "name": "Cacnea",
@@ -9416,7 +10731,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Cacnea",
+                "german": "Tuska"
+            }
         },
         {
             "name": "Cacturne",
@@ -9443,7 +10762,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Cacturne",
+                "german": "Noktuska"
+            }
         },
         {
             "name": "Swablu",
@@ -9470,7 +10793,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Tylton",
+                "german": "Wablu"
+            }
         },
         {
             "name": "Altaria",
@@ -9497,7 +10824,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Altaria",
+                "german": "Altaria"
+            }
         },
         {
             "name": "Zangoose",
@@ -9523,7 +10854,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Mangriff",
+                "german": "Sengo"
+            }
         },
         {
             "name": "Seviper",
@@ -9549,7 +10884,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "S\u00e9viper",
+                "german": "Vipitis"
+            }
         },
         {
             "name": "Lunatone",
@@ -9575,7 +10914,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "S\u00e9l\u00e9roc",
+                "german": "Lunastein"
+            }
         },
         {
             "name": "Solrock",
@@ -9601,7 +10944,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Solaroc",
+                "german": "Sonnfel"
+            }
         },
         {
             "name": "Barboach",
@@ -9629,7 +10976,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Barloche",
+                "german": "Schmerbe"
+            }
         },
         {
             "name": "Whiscash",
@@ -9657,7 +11008,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Barbicha",
+                "german": "Welsar"
+            }
         },
         {
             "name": "Corphish",
@@ -9684,7 +11039,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "\u00c9crapince",
+                "german": "Krebscorps"
+            }
         },
         {
             "name": "Crawdaunt",
@@ -9712,7 +11071,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Colhomard",
+                "german": "Krebutack"
+            }
         },
         {
             "name": "Baltoy",
@@ -9738,7 +11101,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Balbuto",
+                "german": "Puppance"
+            }
         },
         {
             "name": "Claydol",
@@ -9764,7 +11131,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kaorine",
+                "german": "Lepumentas"
+            }
         },
         {
             "name": "Lileep",
@@ -9791,7 +11162,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lilia",
+                "german": "Liliep"
+            }
         },
         {
             "name": "Cradily",
@@ -9818,7 +11193,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Vacilys",
+                "german": "Wielie"
+            }
         },
         {
             "name": "Anorith",
@@ -9845,7 +11224,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Anorith",
+                "german": "Anorith"
+            }
         },
         {
             "name": "Armaldo",
@@ -9872,7 +11255,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Armaldo",
+                "german": "Armaldo"
+            }
         },
         {
             "name": "Feebas",
@@ -9899,7 +11286,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Barpau",
+                "german": "Barschwa"
+            }
         },
         {
             "name": "Milotic",
@@ -9926,7 +11317,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Milobellus",
+                "german": "Milotic"
+            }
         },
         {
             "name": "Castform",
@@ -9951,7 +11346,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Morph\u00e9o",
+                "german": "Formeo"
+            }
         },
         {
             "name": "Kecleon",
@@ -9977,7 +11376,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kecleon",
+                "german": "Kecleon"
+            }
         },
         {
             "name": "Shuppet",
@@ -10004,7 +11407,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Polichombr",
+                "german": "Shuppet"
+            }
         },
         {
             "name": "Banette",
@@ -10031,7 +11438,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Branette",
+                "german": "Banette"
+            }
         },
         {
             "name": "Duskull",
@@ -10057,7 +11468,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Skel\u00e9nox",
+                "german": "Zwirrlicht"
+            }
         },
         {
             "name": "Dusclops",
@@ -10083,7 +11498,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "T\u00e9raclope",
+                "german": "Zwirrklop"
+            }
         },
         {
             "name": "Tropius",
@@ -10111,7 +11530,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Tropius",
+                "german": "Tropius"
+            }
         },
         {
             "name": "Chimecho",
@@ -10136,7 +11559,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "\u00c9oko",
+                "german": "Palimpalim"
+            }
         },
         {
             "name": "Absol",
@@ -10163,7 +11590,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Absol",
+                "german": "Absol"
+            }
         },
         {
             "name": "Wynaut",
@@ -10189,7 +11620,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Ok\u00e9ok\u00e9",
+                "german": "Isso"
+            }
         },
         {
             "name": "Snorunt",
@@ -10216,7 +11651,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Stalgamin",
+                "german": "Schneppke"
+            }
         },
         {
             "name": "Glalie",
@@ -10243,7 +11682,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Oniglali",
+                "german": "Firnontor"
+            }
         },
         {
             "name": "Spheal",
@@ -10271,7 +11714,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Obalie",
+                "german": "Seemops"
+            }
         },
         {
             "name": "Sealeo",
@@ -10299,7 +11746,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Phogleur",
+                "german": "Seejong"
+            }
         },
         {
             "name": "Walrein",
@@ -10327,7 +11778,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kaimorse",
+                "german": "Walraisa"
+            }
         },
         {
             "name": "Clamperl",
@@ -10353,7 +11808,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Coquiperl",
+                "german": "Perlu"
+            }
         },
         {
             "name": "Huntail",
@@ -10379,7 +11838,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Serpang",
+                "german": "Aalabyss"
+            }
         },
         {
             "name": "Gorebyss",
@@ -10405,7 +11868,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Rosabyss",
+                "german": "Saganabyss"
+            }
         },
         {
             "name": "Relicanth",
@@ -10433,7 +11900,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Relicanth",
+                "german": "Relicanth"
+            }
         },
         {
             "name": "Luvdisc",
@@ -10459,7 +11930,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Lovdisc",
+                "german": "Liebiskus"
+            }
         },
         {
             "name": "Bagon",
@@ -10485,7 +11960,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Draby",
+                "german": "Kindwurm"
+            }
         },
         {
             "name": "Shelgon",
@@ -10511,7 +11990,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Drackhaus",
+                "german": "Draschel"
+            }
         },
         {
             "name": "Salamence",
@@ -10538,7 +12021,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Drattak",
+                "german": "Brutalanda"
+            }
         },
         {
             "name": "Beldum",
@@ -10565,7 +12052,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Terhal",
+                "german": "Tanhel"
+            }
         },
         {
             "name": "Metang",
@@ -10592,7 +12083,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "M\u00e9tang",
+                "german": "Metang"
+            }
         },
         {
             "name": "Metagross",
@@ -10619,7 +12114,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "M\u00e9talosse",
+                "german": "Metagross"
+            }
         },
         {
             "name": "Regirock",
@@ -10645,7 +12144,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Regirock",
+                "german": "Regirock"
+            }
         },
         {
             "name": "Regice",
@@ -10671,7 +12174,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Regice",
+                "german": "Regice"
+            }
         },
         {
             "name": "Registeel",
@@ -10697,7 +12204,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Registeel",
+                "german": "Registeel"
+            }
         },
         {
             "name": "Latias",
@@ -10723,7 +12234,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Latias",
+                "german": "Latias"
+            }
         },
         {
             "name": "Latios",
@@ -10749,7 +12264,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Latios",
+                "german": "Latios"
+            }
         },
         {
             "name": "Kyogre",
@@ -10774,7 +12293,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Kyogre",
+                "german": "Kyogre"
+            }
         },
         {
             "name": "Groudon",
@@ -10799,7 +12322,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Groudon",
+                "german": "Groudon"
+            }
         },
         {
             "name": "Rayquaza",
@@ -10825,7 +12352,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Rayquaza",
+                "german": "Rayquaza"
+            }
         },
         {
             "name": "Jirachi",
@@ -10851,7 +12382,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Jirachi",
+                "german": "Jirachi"
+            }
         },
         {
             "name": "Deoxys",
@@ -10876,7 +12411,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 3
+            "gen": 3,
+            "name_language": {
+                "french": "Deoxys",
+                "german": "Deoxys"
+            }
         },
         {
             "name": "Turtwig",
@@ -10902,7 +12441,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Tortipouss",
+                "german": "Chelast"
+            }
         },
         {
             "name": "Grotle",
@@ -10928,7 +12471,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Boskara",
+                "german": "Chelcarain"
+            }
         },
         {
             "name": "Torterra",
@@ -10955,7 +12502,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Torterra",
+                "german": "Chelterrar"
+            }
         },
         {
             "name": "Chimchar",
@@ -10981,7 +12532,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Ouisticram",
+                "german": "Panflam"
+            }
         },
         {
             "name": "Monferno",
@@ -11008,7 +12563,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Chimpenfeu",
+                "german": "Panpyro"
+            }
         },
         {
             "name": "Infernape",
@@ -11035,7 +12594,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Simiabraz",
+                "german": "Panferno"
+            }
         },
         {
             "name": "Piplup",
@@ -11061,7 +12624,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Tiplouf",
+                "german": "Plinfa"
+            }
         },
         {
             "name": "Prinplup",
@@ -11087,7 +12654,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Prinplouf",
+                "german": "Pliprin"
+            }
         },
         {
             "name": "Empoleon",
@@ -11114,7 +12685,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Pingol\u00e9on",
+                "german": "Impoleon"
+            }
         },
         {
             "name": "Starly",
@@ -11141,7 +12716,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "\u00c9tourmi",
+                "german": "Staralili"
+            }
         },
         {
             "name": "Staravia",
@@ -11168,7 +12747,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "\u00c9tourvol",
+                "german": "Staravia"
+            }
         },
         {
             "name": "Staraptor",
@@ -11195,7 +12778,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "\u00c9touraptor",
+                "german": "Staraptor"
+            }
         },
         {
             "name": "Bidoof",
@@ -11222,7 +12809,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Keunotor",
+                "german": "Bidiza"
+            }
         },
         {
             "name": "Bibarel",
@@ -11250,7 +12841,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Castorno",
+                "german": "Bidifas"
+            }
         },
         {
             "name": "Kricketot",
@@ -11276,7 +12871,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Crikzik",
+                "german": "Zirpurze"
+            }
         },
         {
             "name": "Kricketune",
@@ -11302,7 +12901,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "M\u00e9lokrik",
+                "german": "Zirpeise"
+            }
         },
         {
             "name": "Shinx",
@@ -11329,7 +12932,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Lixy",
+                "german": "Sheinux"
+            }
         },
         {
             "name": "Luxio",
@@ -11356,7 +12963,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Luxio",
+                "german": "Luxio"
+            }
         },
         {
             "name": "Luxray",
@@ -11383,7 +12994,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Luxray",
+                "german": "Luxtra"
+            }
         },
         {
             "name": "Budew",
@@ -11411,7 +13026,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Rozbouton",
+                "german": "Knospi"
+            }
         },
         {
             "name": "Roserade",
@@ -11439,7 +13058,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Roserade",
+                "german": "Roserade"
+            }
         },
         {
             "name": "Cranidos",
@@ -11465,7 +13088,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Kranidos",
+                "german": "Koknodon"
+            }
         },
         {
             "name": "Rampardos",
@@ -11491,7 +13118,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Charkos",
+                "german": "Rameidon"
+            }
         },
         {
             "name": "Shieldon",
@@ -11518,7 +13149,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Dinoclier",
+                "german": "Schilterus"
+            }
         },
         {
             "name": "Bastiodon",
@@ -11545,7 +13180,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Bastiodon",
+                "german": "Bollterus"
+            }
         },
         {
             "name": "Burmy",
@@ -11571,7 +13210,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cheniti",
+                "german": "Burmy"
+            }
         },
         {
             "name": "Wormadam",
@@ -11598,7 +13241,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cheniselle",
+                "german": "Burmadame"
+            }
         },
         {
             "name": "Mothim",
@@ -11625,7 +13272,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Papilord",
+                "german": "Moterpel"
+            }
         },
         {
             "name": "Combee",
@@ -11652,7 +13303,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Apitrini",
+                "german": "Wadribie"
+            }
         },
         {
             "name": "Vespiquen",
@@ -11679,7 +13334,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Apireine",
+                "german": "Honweisel"
+            }
         },
         {
             "name": "Pachirisu",
@@ -11706,7 +13365,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Pachirisu",
+                "german": "Pachirisu"
+            }
         },
         {
             "name": "Buizel",
@@ -11732,7 +13395,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Must\u00e9bou\u00e9e",
+                "german": "Bamelin"
+            }
         },
         {
             "name": "Floatzel",
@@ -11758,7 +13425,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Must\u00e9flott",
+                "german": "Bojelin"
+            }
         },
         {
             "name": "Cherubi",
@@ -11783,7 +13454,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Ceribou",
+                "german": "Kikugi"
+            }
         },
         {
             "name": "Cherrim",
@@ -11808,7 +13483,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Ceriflor",
+                "german": "Kinoso"
+            }
         },
         {
             "name": "Shellos",
@@ -11835,7 +13514,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Sancoki",
+                "german": "Schalellos"
+            }
         },
         {
             "name": "Gastrodon",
@@ -11863,7 +13546,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Tritosor",
+                "german": "Gastrodon"
+            }
         },
         {
             "name": "Ambipom",
@@ -11890,7 +13577,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Capidextre",
+                "german": "Ambidiffel"
+            }
         },
         {
             "name": "Drifloon",
@@ -11918,7 +13609,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Baudrive",
+                "german": "Driftlon"
+            }
         },
         {
             "name": "Drifblim",
@@ -11946,7 +13641,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Grodrive",
+                "german": "Drifzepeli"
+            }
         },
         {
             "name": "Buneary",
@@ -11973,7 +13672,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Laporeille",
+                "german": "Haspiror"
+            }
         },
         {
             "name": "Lopunny",
@@ -12000,7 +13703,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Lockpin",
+                "german": "Schlapor"
+            }
         },
         {
             "name": "Mismagius",
@@ -12025,7 +13732,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Magir\u00eave",
+                "german": "Traunmagil"
+            }
         },
         {
             "name": "Honchkrow",
@@ -12053,7 +13764,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Corboss",
+                "german": "Kramshef"
+            }
         },
         {
             "name": "Glameow",
@@ -12080,7 +13795,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Chaglam",
+                "german": "Charmian"
+            }
         },
         {
             "name": "Purugly",
@@ -12107,7 +13826,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Chaffreux",
+                "german": "Shnurgarst"
+            }
         },
         {
             "name": "Chingling",
@@ -12132,7 +13855,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Korillon",
+                "german": "Klingplim"
+            }
         },
         {
             "name": "Stunky",
@@ -12160,7 +13887,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Moufouette",
+                "german": "Skunkapuh"
+            }
         },
         {
             "name": "Skuntank",
@@ -12188,7 +13919,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Moufflair",
+                "german": "Skunktank"
+            }
         },
         {
             "name": "Bronzor",
@@ -12216,7 +13951,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Arch\u00e9omire",
+                "german": "Bronzel"
+            }
         },
         {
             "name": "Bronzong",
@@ -12244,7 +13983,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Arch\u00e9odong",
+                "german": "Bronzong"
+            }
         },
         {
             "name": "Bonsly",
@@ -12271,7 +14014,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Manza\u00ef",
+                "german": "Mobai"
+            }
         },
         {
             "name": "Mime Jr.",
@@ -12299,7 +14046,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Jr",
+                "german": "Pantimimi"
+            }
         },
         {
             "name": "Happiny",
@@ -12326,7 +14077,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Ptiravi",
+                "german": "Wonneira"
+            }
         },
         {
             "name": "Chatot",
@@ -12354,7 +14109,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Pijako",
+                "german": "Plaudagei"
+            }
         },
         {
             "name": "Spiritomb",
@@ -12381,7 +14140,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Spiritomb",
+                "german": "Kryppuk"
+            }
         },
         {
             "name": "Gible",
@@ -12408,7 +14171,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Griknot",
+                "german": "Kaumalat"
+            }
         },
         {
             "name": "Gabite",
@@ -12435,7 +14202,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Carmache",
+                "german": "Knarksel"
+            }
         },
         {
             "name": "Garchomp",
@@ -12462,7 +14233,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Carchacrok",
+                "german": "Knakrack"
+            }
         },
         {
             "name": "Munchlax",
@@ -12489,7 +14264,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Goinfrex",
+                "german": "Mampfaxo"
+            }
         },
         {
             "name": "Riolu",
@@ -12516,7 +14295,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Riolu",
+                "german": "Riolu"
+            }
         },
         {
             "name": "Lucario",
@@ -12544,7 +14327,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Lucario",
+                "german": "Lucario"
+            }
         },
         {
             "name": "Hippopotas",
@@ -12570,7 +14357,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Hippopotas",
+                "german": "Hippopotas"
+            }
         },
         {
             "name": "Hippowdon",
@@ -12596,7 +14387,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Hippodocus",
+                "german": "Hippoterus"
+            }
         },
         {
             "name": "Skorupi",
@@ -12624,7 +14419,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Rapion",
+                "german": "Pionskora"
+            }
         },
         {
             "name": "Drapion",
@@ -12652,7 +14451,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Drascore",
+                "german": "Piondragi"
+            }
         },
         {
             "name": "Croagunk",
@@ -12680,7 +14483,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cradopaud",
+                "german": "Glibunkel"
+            }
         },
         {
             "name": "Toxicroak",
@@ -12708,7 +14515,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Coatox",
+                "german": "Toxiquak"
+            }
         },
         {
             "name": "Carnivine",
@@ -12733,7 +14544,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Vortente",
+                "german": "Venuflibis"
+            }
         },
         {
             "name": "Finneon",
@@ -12760,7 +14575,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "\u00c9cayon",
+                "german": "Finneon"
+            }
         },
         {
             "name": "Lumineon",
@@ -12787,7 +14606,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Lumin\u00e9on",
+                "german": "Lumineon"
+            }
         },
         {
             "name": "Mantyke",
@@ -12815,7 +14638,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Babimanta",
+                "german": "Mantirps"
+            }
         },
         {
             "name": "Snover",
@@ -12842,7 +14669,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Blizzi",
+                "german": "Shnebedeck"
+            }
         },
         {
             "name": "Abomasnow",
@@ -12869,7 +14700,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Blizzaroi",
+                "german": "Rexblisar"
+            }
         },
         {
             "name": "Weavile",
@@ -12896,7 +14731,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Dimoret",
+                "german": "Snibunna"
+            }
         },
         {
             "name": "Magnezone",
@@ -12924,7 +14763,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Magn\u00e9zone",
+                "german": "Magnezone"
+            }
         },
         {
             "name": "Lickilicky",
@@ -12951,7 +14794,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Coudlangue",
+                "german": "Schlurplek"
+            }
         },
         {
             "name": "Rhyperior",
@@ -12979,7 +14826,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Rhinastoc",
+                "german": "Rihornior"
+            }
         },
         {
             "name": "Tangrowth",
@@ -13006,7 +14857,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Bouldeneu",
+                "german": "Tangoloss"
+            }
         },
         {
             "name": "Electivire",
@@ -13032,7 +14887,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "\u00c9lekable",
+                "german": "Elevoltek"
+            }
         },
         {
             "name": "Magmortar",
@@ -13058,7 +14917,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Maganon",
+                "german": "Magbrant"
+            }
         },
         {
             "name": "Togekiss",
@@ -13086,7 +14949,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Togekiss",
+                "german": "Togekiss"
+            }
         },
         {
             "name": "Yanmega",
@@ -13114,7 +14981,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Yanm\u00e9ga",
+                "german": "Yanmega"
+            }
         },
         {
             "name": "Leafeon",
@@ -13140,7 +15011,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Phyllali",
+                "german": "Folipurba"
+            }
         },
         {
             "name": "Glaceon",
@@ -13166,7 +15041,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Givrali",
+                "german": "Glaziola"
+            }
         },
         {
             "name": "Gliscor",
@@ -13194,7 +15073,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Scorvol",
+                "german": "Skorgro"
+            }
         },
         {
             "name": "Mamoswine",
@@ -13222,7 +15105,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Mammochon",
+                "german": "Mamutel"
+            }
         },
         {
             "name": "Porygon-Z",
@@ -13249,7 +15136,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Z",
+                "german": "Porygon-Z"
+            }
         },
         {
             "name": "Gallade",
@@ -13276,7 +15167,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Gallame",
+                "german": "Galagladi"
+            }
         },
         {
             "name": "Probopass",
@@ -13304,7 +15199,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Tarinorme",
+                "german": "Voluminas"
+            }
         },
         {
             "name": "Dusknoir",
@@ -13330,7 +15229,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Noctunoir",
+                "german": "Zwirrfinst"
+            }
         },
         {
             "name": "Froslass",
@@ -13357,7 +15260,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Momartik",
+                "german": "Frosdedje"
+            }
         },
         {
             "name": "Rotom",
@@ -13383,7 +15290,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Motisma",
+                "german": "Rotom"
+            }
         },
         {
             "name": "Uxie",
@@ -13408,7 +15319,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cr\u00e9helf",
+                "german": "Selfe"
+            }
         },
         {
             "name": "Mesprit",
@@ -13433,7 +15348,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cr\u00e9follet",
+                "german": "Vesprit"
+            }
         },
         {
             "name": "Azelf",
@@ -13458,7 +15377,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cr\u00e9fadet",
+                "german": "Tobutz"
+            }
         },
         {
             "name": "Dialga",
@@ -13485,7 +15408,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Dialga",
+                "german": "Dialga"
+            }
         },
         {
             "name": "Palkia",
@@ -13512,7 +15439,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Palkia",
+                "german": "Palkia"
+            }
         },
         {
             "name": "Heatran",
@@ -13539,7 +15470,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Heatran",
+                "german": "Heatran"
+            }
         },
         {
             "name": "Regigigas",
@@ -13564,7 +15499,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Regigigas",
+                "german": "Regigigas"
+            }
         },
         {
             "name": "Giratina",
@@ -13592,7 +15531,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Giratina",
+                "german": "Giratina"
+            }
         },
         {
             "name": "Cresselia",
@@ -13617,7 +15560,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Cresselia",
+                "german": "Cresselia"
+            }
         },
         {
             "name": "Phione",
@@ -13642,7 +15589,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Phione",
+                "german": "Phione"
+            }
         },
         {
             "name": "Manaphy",
@@ -13667,7 +15618,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Manaphy",
+                "german": "Manaphy"
+            }
         },
         {
             "name": "Darkrai",
@@ -13692,7 +15647,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Darkrai",
+                "german": "Darkrai"
+            }
         },
         {
             "name": "Shaymin",
@@ -13719,7 +15678,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Shaymin",
+                "german": "Shaymin"
+            }
         },
         {
             "name": "Arceus",
@@ -13744,7 +15707,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 4
+            "gen": 4,
+            "name_language": {
+                "french": "Arceus",
+                "german": "Arceus"
+            }
         },
         {
             "name": "Victini",
@@ -13770,7 +15737,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Victini",
+                "german": "Victini"
+            }
         },
         {
             "name": "Snivy",
@@ -13796,7 +15767,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Vip\u00e9lierre",
+                "german": "Serpifeu"
+            }
         },
         {
             "name": "Servine",
@@ -13822,7 +15797,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lianaja",
+                "german": "Efoserp"
+            }
         },
         {
             "name": "Serperior",
@@ -13848,7 +15827,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Majaspic",
+                "german": "Serpiroyal"
+            }
         },
         {
             "name": "Tepig",
@@ -13874,7 +15857,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Gruikui",
+                "german": "Floink"
+            }
         },
         {
             "name": "Pignite",
@@ -13901,7 +15888,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Grotichon",
+                "german": "Ferkokel"
+            }
         },
         {
             "name": "Emboar",
@@ -13928,7 +15919,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Roitiflam",
+                "german": "Flambirex"
+            }
         },
         {
             "name": "Oshawott",
@@ -13954,7 +15949,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Moustillon",
+                "german": "Ottaro"
+            }
         },
         {
             "name": "Dewott",
@@ -13980,7 +15979,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mateloutre",
+                "german": "Zwottronin"
+            }
         },
         {
             "name": "Samurott",
@@ -14006,7 +16009,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Clamiral",
+                "german": "Admurai"
+            }
         },
         {
             "name": "Patrat",
@@ -14033,7 +16040,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ratentif",
+                "german": "Nagelotz"
+            }
         },
         {
             "name": "Watchog",
@@ -14060,7 +16071,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Miradar",
+                "german": "Kukmarda"
+            }
         },
         {
             "name": "Lillipup",
@@ -14087,7 +16102,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ponchiot",
+                "german": "Yorkleff"
+            }
         },
         {
             "name": "Herdier",
@@ -14114,7 +16133,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ponchien",
+                "german": "Terribark"
+            }
         },
         {
             "name": "Stoutland",
@@ -14141,7 +16164,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mastouffe",
+                "german": "Bissbark"
+            }
         },
         {
             "name": "Purrloin",
@@ -14168,7 +16195,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Chacripan",
+                "german": "Felilou"
+            }
         },
         {
             "name": "Liepard",
@@ -14195,7 +16226,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "L\u00e9opardus",
+                "german": "Kleoparda"
+            }
         },
         {
             "name": "Pansage",
@@ -14221,7 +16256,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Feuillajou",
+                "german": "Vegimak"
+            }
         },
         {
             "name": "Simisage",
@@ -14247,7 +16286,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Feuiloutan",
+                "german": "Vegichita"
+            }
         },
         {
             "name": "Pansear",
@@ -14273,7 +16316,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Flamajou",
+                "german": "Grillmak"
+            }
         },
         {
             "name": "Simisear",
@@ -14299,7 +16346,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Flamoutan",
+                "german": "Grillchita"
+            }
         },
         {
             "name": "Panpour",
@@ -14325,7 +16376,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Flotajou",
+                "german": "Sodamak"
+            }
         },
         {
             "name": "Simipour",
@@ -14351,7 +16406,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Flotoutan",
+                "german": "Sodachita"
+            }
         },
         {
             "name": "Munna",
@@ -14378,7 +16437,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Munna",
+                "german": "Somniam"
+            }
         },
         {
             "name": "Musharna",
@@ -14405,7 +16468,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mushana",
+                "german": "Somnivora"
+            }
         },
         {
             "name": "Pidove",
@@ -14433,7 +16500,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Poichigeon",
+                "german": "Dusselgurr"
+            }
         },
         {
             "name": "Tranquill",
@@ -14461,7 +16532,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Colombeau",
+                "german": "Navitaub"
+            }
         },
         {
             "name": "Unfezant",
@@ -14489,7 +16564,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "D\u00e9flaisan",
+                "german": "Fasasnob"
+            }
         },
         {
             "name": "Blitzle",
@@ -14516,7 +16595,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Z\u00e9bribon",
+                "german": "Elezeba"
+            }
         },
         {
             "name": "Zebstrika",
@@ -14543,7 +16626,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Z\u00e9blitz",
+                "german": "Zebritz"
+            }
         },
         {
             "name": "Roggenrola",
@@ -14570,7 +16657,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Nodulithe",
+                "german": "Kiesling"
+            }
         },
         {
             "name": "Boldore",
@@ -14597,7 +16688,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "G\u00e9olithe",
+                "german": "Sedimantur"
+            }
         },
         {
             "name": "Gigalith",
@@ -14624,7 +16719,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Gigalithe",
+                "german": "Brockoloss"
+            }
         },
         {
             "name": "Woobat",
@@ -14652,7 +16751,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Chovsourir",
+                "german": "Fleknoil"
+            }
         },
         {
             "name": "Swoobat",
@@ -14680,7 +16783,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Rhinolove",
+                "german": "Fletiamo"
+            }
         },
         {
             "name": "Drilbur",
@@ -14707,7 +16814,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Rototaupe",
+                "german": "Rotomurf"
+            }
         },
         {
             "name": "Excadrill",
@@ -14735,7 +16846,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Minotaupe",
+                "german": "Stalobor"
+            }
         },
         {
             "name": "Audino",
@@ -14762,7 +16877,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Nanm\u00e9ou\u00efe",
+                "german": "Ohrdoch"
+            }
         },
         {
             "name": "Timburr",
@@ -14789,7 +16908,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Charpenti",
+                "german": "Praktibalk"
+            }
         },
         {
             "name": "Gurdurr",
@@ -14816,7 +16939,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ouvrifier",
+                "german": "Strepoli"
+            }
         },
         {
             "name": "Conkeldurr",
@@ -14843,7 +16970,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "B\u00e9tochef",
+                "german": "Meistagrif"
+            }
         },
         {
             "name": "Tympole",
@@ -14870,7 +17001,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Tritonde",
+                "german": "Schallquap"
+            }
         },
         {
             "name": "Palpitoad",
@@ -14898,7 +17033,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Batracn\u00e9",
+                "german": "Mebrana"
+            }
         },
         {
             "name": "Seismitoad",
@@ -14926,7 +17065,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Crapustule",
+                "german": "Branawarz"
+            }
         },
         {
             "name": "Throh",
@@ -14953,7 +17096,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Judokrak",
+                "german": "Jiutesto"
+            }
         },
         {
             "name": "Sawk",
@@ -14980,7 +17127,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Karacl\u00e9e",
+                "german": "Karadonis"
+            }
         },
         {
             "name": "Sewaddle",
@@ -15008,7 +17159,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Larveyette",
+                "german": "Strawickl"
+            }
         },
         {
             "name": "Swadloon",
@@ -15036,7 +17191,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Couverdure",
+                "german": "Folikon"
+            }
         },
         {
             "name": "Leavanny",
@@ -15064,7 +17223,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Manternel",
+                "german": "Matrifol"
+            }
         },
         {
             "name": "Venipede",
@@ -15092,7 +17255,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Venipatte",
+                "german": "Toxiped"
+            }
         },
         {
             "name": "Whirlipede",
@@ -15120,7 +17287,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Scobolide",
+                "german": "Rollum"
+            }
         },
         {
             "name": "Scolipede",
@@ -15148,7 +17319,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Brutapode",
+                "german": "Cerapendra"
+            }
         },
         {
             "name": "Cottonee",
@@ -15176,7 +17351,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Doudouvet",
+                "german": "Waumboll"
+            }
         },
         {
             "name": "Whimsicott",
@@ -15204,7 +17383,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Farfaduvet",
+                "german": "Elfun"
+            }
         },
         {
             "name": "Petilil",
@@ -15231,7 +17414,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Chlorobule",
+                "german": "Lilminip"
+            }
         },
         {
             "name": "Lilligant",
@@ -15258,7 +17445,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Fragilady",
+                "german": "Dressella"
+            }
         },
         {
             "name": "Basculin",
@@ -15286,7 +17477,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Bargantua",
+                "german": "Barschuft"
+            }
         },
         {
             "name": "Sandile",
@@ -15314,7 +17509,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Masca\u00efman",
+                "german": "Ganovil"
+            }
         },
         {
             "name": "Krokorok",
@@ -15342,7 +17541,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Escroco",
+                "german": "Rokkaiman"
+            }
         },
         {
             "name": "Krookodile",
@@ -15370,7 +17573,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Crocorible",
+                "german": "Rabigator"
+            }
         },
         {
             "name": "Darumaka",
@@ -15396,7 +17603,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Darumarond",
+                "german": "Flampion"
+            }
         },
         {
             "name": "Darmanitan",
@@ -15423,7 +17634,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Darumacho",
+                "german": "Flampivian"
+            }
         },
         {
             "name": "Maractus",
@@ -15450,7 +17665,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Maracachi",
+                "german": "Maracamba"
+            }
         },
         {
             "name": "Dwebble",
@@ -15478,7 +17697,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Crabicoque",
+                "german": "Lithomith"
+            }
         },
         {
             "name": "Crustle",
@@ -15506,7 +17729,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Crabaraque",
+                "german": "Castellith"
+            }
         },
         {
             "name": "Scraggy",
@@ -15534,7 +17761,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Baggiguane",
+                "german": "Zurrokex"
+            }
         },
         {
             "name": "Scrafty",
@@ -15562,7 +17793,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Bagga\u00efd",
+                "german": "Irokex"
+            }
         },
         {
             "name": "Sigilyph",
@@ -15590,7 +17825,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Crypt\u00e9ro",
+                "german": "Symvolara"
+            }
         },
         {
             "name": "Yamask",
@@ -15615,7 +17854,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Tutafeh",
+                "german": "Makabaja"
+            }
         },
         {
             "name": "Cofagrigus",
@@ -15640,7 +17883,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Tutankafer",
+                "german": "Echnatoll"
+            }
         },
         {
             "name": "Tirtouga",
@@ -15668,7 +17915,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Carapagos",
+                "german": "Galapaflos"
+            }
         },
         {
             "name": "Carracosta",
@@ -15696,7 +17947,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "M\u00e9gapagos",
+                "german": "Karippas"
+            }
         },
         {
             "name": "Archen",
@@ -15722,7 +17977,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ark\u00e9apti",
+                "german": "Flapteryx"
+            }
         },
         {
             "name": "Archeops",
@@ -15748,7 +18007,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "A\u00e9ropt\u00e9ryx",
+                "german": "Aeropteryx"
+            }
         },
         {
             "name": "Trubbish",
@@ -15775,7 +18038,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Miamiasme",
+                "german": "Unrat\u00fctox"
+            }
         },
         {
             "name": "Garbodor",
@@ -15802,7 +18069,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Miasmax",
+                "german": "Deponitox"
+            }
         },
         {
             "name": "Zorua",
@@ -15827,7 +18098,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Zorua",
+                "german": "Zorua"
+            }
         },
         {
             "name": "Zoroark",
@@ -15852,7 +18127,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Zoroark",
+                "german": "Zoroark"
+            }
         },
         {
             "name": "Minccino",
@@ -15879,7 +18158,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Chinchidou",
+                "german": "Picochilla"
+            }
         },
         {
             "name": "Cinccino",
@@ -15906,7 +18189,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Pashmilla",
+                "german": "Chillabell"
+            }
         },
         {
             "name": "Gothita",
@@ -15933,7 +18220,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Scrutella",
+                "german": "Mollimorba"
+            }
         },
         {
             "name": "Gothorita",
@@ -15960,7 +18251,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mesm\u00e9rella",
+                "german": "Hypnomorba"
+            }
         },
         {
             "name": "Gothitelle",
@@ -15987,7 +18282,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Sid\u00e9rella",
+                "german": "Morbitesse"
+            }
         },
         {
             "name": "Solosis",
@@ -16014,7 +18313,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Nucl\u00e9os",
+                "german": "Monozyto"
+            }
         },
         {
             "name": "Duosion",
@@ -16041,7 +18344,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "M\u00e9ios",
+                "german": "Mitodos"
+            }
         },
         {
             "name": "Reuniclus",
@@ -16068,7 +18375,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Symbios",
+                "german": "Zytomega"
+            }
         },
         {
             "name": "Ducklett",
@@ -16096,7 +18407,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Couaneton",
+                "german": "Piccolente"
+            }
         },
         {
             "name": "Swanna",
@@ -16124,7 +18439,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lakm\u00e9cygne",
+                "german": "Swaroness"
+            }
         },
         {
             "name": "Vanillite",
@@ -16151,7 +18470,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Sorb\u00e9b\u00e9",
+                "german": "Gelatini"
+            }
         },
         {
             "name": "Vanillish",
@@ -16178,7 +18501,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Sorboul",
+                "german": "Gelatroppo"
+            }
         },
         {
             "name": "Vanilluxe",
@@ -16205,7 +18532,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Sorbouboul",
+                "german": "Gelatwino"
+            }
         },
         {
             "name": "Deerling",
@@ -16233,7 +18564,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Vivaldaim",
+                "german": "Sesokitz"
+            }
         },
         {
             "name": "Sawsbuck",
@@ -16261,7 +18596,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Haydaim",
+                "german": "Kronjuwild"
+            }
         },
         {
             "name": "Emolga",
@@ -16288,7 +18627,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Emolga",
+                "german": "Emolga"
+            }
         },
         {
             "name": "Karrablast",
@@ -16315,7 +18658,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Carabing",
+                "german": "Laukaps"
+            }
         },
         {
             "name": "Escavalier",
@@ -16343,7 +18690,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lan\u00e7argot",
+                "german": "Cavalanzas"
+            }
         },
         {
             "name": "Foongus",
@@ -16370,7 +18721,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Trompignon",
+                "german": "Tarnpignon"
+            }
         },
         {
             "name": "Amoonguss",
@@ -16397,7 +18752,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Gaulet",
+                "german": "Hutsassa"
+            }
         },
         {
             "name": "Frillish",
@@ -16425,7 +18784,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Viskuse",
+                "german": "Quabbel"
+            }
         },
         {
             "name": "Jellicent",
@@ -16453,7 +18816,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Moyade",
+                "german": "Apoquallyp"
+            }
         },
         {
             "name": "Alomomola",
@@ -16480,7 +18847,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mamanbo",
+                "german": "Mamolida"
+            }
         },
         {
             "name": "Joltik",
@@ -16508,7 +18879,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Statitik",
+                "german": "Wattzapf"
+            }
         },
         {
             "name": "Galvantula",
@@ -16536,7 +18911,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Mygavolt",
+                "german": "Voltula"
+            }
         },
         {
             "name": "Ferroseed",
@@ -16562,7 +18941,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Grindur",
+                "german": "Kastadur"
+            }
         },
         {
             "name": "Ferrothorn",
@@ -16589,7 +18972,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Noacier",
+                "german": "Tentantel"
+            }
         },
         {
             "name": "Klink",
@@ -16616,7 +19003,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Tic",
+                "german": "Klikk"
+            }
         },
         {
             "name": "Klang",
@@ -16643,7 +19034,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Clic",
+                "german": "Kliklak"
+            }
         },
         {
             "name": "Klinklang",
@@ -16670,7 +19065,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Cliticlic",
+                "german": "Klikdiklak"
+            }
         },
         {
             "name": "Tynamo",
@@ -16695,7 +19094,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Anchwatt",
+                "german": "Zapplardin"
+            }
         },
         {
             "name": "Eelektrik",
@@ -16720,7 +19123,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lamp\u00e9roie",
+                "german": "Zapplalek"
+            }
         },
         {
             "name": "Eelektross",
@@ -16745,7 +19152,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Ohmassacre",
+                "german": "Zapplarang"
+            }
         },
         {
             "name": "Elgyem",
@@ -16772,7 +19183,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lewsor",
+                "german": "Pygraulon"
+            }
         },
         {
             "name": "Beheeyem",
@@ -16799,7 +19214,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Neitram",
+                "german": "Megalon"
+            }
         },
         {
             "name": "Litwick",
@@ -16827,7 +19246,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Fun\u00e9cire",
+                "german": "Lichtel"
+            }
         },
         {
             "name": "Lampent",
@@ -16855,7 +19278,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "M\u00e9lancolux",
+                "german": "Laternecto"
+            }
         },
         {
             "name": "Chandelure",
@@ -16883,7 +19310,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Lugulabre",
+                "german": "Skelabra"
+            }
         },
         {
             "name": "Axew",
@@ -16910,7 +19341,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Coupenotte",
+                "german": "Milza"
+            }
         },
         {
             "name": "Fraxure",
@@ -16937,7 +19372,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Incisache",
+                "german": "Sharfax"
+            }
         },
         {
             "name": "Haxorus",
@@ -16964,7 +19403,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Tranchodon",
+                "german": "Maxax"
+            }
         },
         {
             "name": "Cubchoo",
@@ -16991,7 +19434,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Polarhume",
+                "german": "Petznief"
+            }
         },
         {
             "name": "Beartic",
@@ -17018,7 +19465,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Polagriffe",
+                "german": "Siberio"
+            }
         },
         {
             "name": "Cryogonal",
@@ -17043,7 +19494,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Hexagel",
+                "german": "Frigometri"
+            }
         },
         {
             "name": "Shelmet",
@@ -17070,7 +19525,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Escargaume",
+                "german": "Schnuthelm"
+            }
         },
         {
             "name": "Accelgor",
@@ -17097,7 +19556,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Limaspeed",
+                "german": "Hydragil"
+            }
         },
         {
             "name": "Stunfisk",
@@ -17125,7 +19588,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Limonde",
+                "german": "Flunschlik"
+            }
         },
         {
             "name": "Mienfoo",
@@ -17152,7 +19619,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Kungfouine",
+                "german": "Fu"
+            }
         },
         {
             "name": "Mienshao",
@@ -17179,7 +19650,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Shaofouine",
+                "german": "Shu"
+            }
         },
         {
             "name": "Druddigon",
@@ -17206,7 +19681,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Drakkarmin",
+                "german": "Shardrago"
+            }
         },
         {
             "name": "Golett",
@@ -17234,7 +19713,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Gringolem",
+                "german": "Golbit"
+            }
         },
         {
             "name": "Golurk",
@@ -17262,7 +19745,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Golemastoc",
+                "german": "Golgantes"
+            }
         },
         {
             "name": "Pawniard",
@@ -17290,7 +19777,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Scalpion",
+                "german": "Gladiantri"
+            }
         },
         {
             "name": "Bisharp",
@@ -17318,7 +19809,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Scalproie",
+                "german": "Caesurio"
+            }
         },
         {
             "name": "Bouffalant",
@@ -17345,7 +19840,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Frison",
+                "german": "Bisofank"
+            }
         },
         {
             "name": "Rufflet",
@@ -17373,7 +19872,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Furaiglon",
+                "german": "Geronimatz"
+            }
         },
         {
             "name": "Braviary",
@@ -17401,7 +19904,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Gueriaigle",
+                "german": "Washakwil"
+            }
         },
         {
             "name": "Vullaby",
@@ -17429,7 +19936,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Vostourno",
+                "german": "Skallyk"
+            }
         },
         {
             "name": "Mandibuzz",
@@ -17457,7 +19968,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Vaututrice",
+                "german": "Grypheldis"
+            }
         },
         {
             "name": "Heatmor",
@@ -17484,7 +19999,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Aflamanoir",
+                "german": "Furnifra\u00df"
+            }
         },
         {
             "name": "Durant",
@@ -17512,7 +20031,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Fermite",
+                "german": "Fermicula"
+            }
         },
         {
             "name": "Deino",
@@ -17538,7 +20061,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Solochi",
+                "german": "Kapuno"
+            }
         },
         {
             "name": "Zweilous",
@@ -17564,7 +20091,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Diamat",
+                "german": "Duodino"
+            }
         },
         {
             "name": "Hydreigon",
@@ -17590,7 +20121,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Trioxhydre",
+                "german": "Trikephalo"
+            }
         },
         {
             "name": "Larvesta",
@@ -17617,7 +20152,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Pyronille",
+                "german": "Ignivor"
+            }
         },
         {
             "name": "Volcarona",
@@ -17644,7 +20183,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Pyrax",
+                "german": "Ramoth"
+            }
         },
         {
             "name": "Cobalion",
@@ -17670,7 +20213,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Cobaltium",
+                "german": "Kobalium"
+            }
         },
         {
             "name": "Terrakion",
@@ -17696,7 +20243,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Terrakium",
+                "german": "Terrakium"
+            }
         },
         {
             "name": "Virizion",
@@ -17722,7 +20273,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Viridium",
+                "german": "Viridium"
+            }
         },
         {
             "name": "Tornadus",
@@ -17749,7 +20304,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Bor\u00e9as",
+                "german": "Boreos"
+            }
         },
         {
             "name": "Thundurus",
@@ -17777,7 +20336,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Fulguris",
+                "german": "Voltolos"
+            }
         },
         {
             "name": "Reshiram",
@@ -17803,7 +20366,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Reshiram",
+                "german": "Reshiram"
+            }
         },
         {
             "name": "Zekrom",
@@ -17829,7 +20396,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Zekrom",
+                "german": "Zekrom"
+            }
         },
         {
             "name": "Landorus",
@@ -17857,7 +20428,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "D\u00e9m\u00e9t\u00e9ros",
+                "german": "Demeteros"
+            }
         },
         {
             "name": "Kyurem",
@@ -17885,7 +20460,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Kyurem",
+                "german": "Kyurem"
+            }
         },
         {
             "name": "Keldeo",
@@ -17911,7 +20490,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Keldeo",
+                "german": "Keldeo"
+            }
         },
         {
             "name": "Meloetta",
@@ -17937,7 +20520,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Meloetta",
+                "german": "Meloetta"
+            }
         },
         {
             "name": "Genesect",
@@ -17963,7 +20550,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 5
+            "gen": 5,
+            "name_language": {
+                "french": "Genesect",
+                "german": "Genesect"
+            }
         },
         {
             "name": "Chespin",
@@ -17989,7 +20580,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Marisson",
+                "german": "Igamaro"
+            }
         },
         {
             "name": "Quilladin",
@@ -18015,7 +20610,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Bogu\u00e9risse",
+                "german": "Igastarnish"
+            }
         },
         {
             "name": "Chesnaught",
@@ -18042,7 +20641,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Blind\u00e9pique",
+                "german": "Brigaron"
+            }
         },
         {
             "name": "Fennekin",
@@ -18068,7 +20671,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Feunnec",
+                "german": "Fynx"
+            }
         },
         {
             "name": "Braixen",
@@ -18094,7 +20701,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Roussil",
+                "german": "Rutena"
+            }
         },
         {
             "name": "Delphox",
@@ -18121,7 +20732,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Goupelin",
+                "german": "Fennexis"
+            }
         },
         {
             "name": "Froakie",
@@ -18147,7 +20762,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Grenousse",
+                "german": "Froxy"
+            }
         },
         {
             "name": "Frogadier",
@@ -18173,7 +20792,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Cro\u00e2poral",
+                "german": "Amphizel"
+            }
         },
         {
             "name": "Greninja",
@@ -18201,7 +20824,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Amphinobi",
+                "german": "Quajutsu"
+            }
         },
         {
             "name": "Bunnelby",
@@ -18228,7 +20855,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Sapereau",
+                "german": "Scoppel"
+            }
         },
         {
             "name": "Diggersby",
@@ -18256,7 +20887,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Excavarenne",
+                "german": "Grebbit"
+            }
         },
         {
             "name": "Fletchling",
@@ -18283,7 +20918,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Passerouge",
+                "german": "Dartiri"
+            }
         },
         {
             "name": "Fletchinder",
@@ -18310,7 +20949,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Braisillon",
+                "german": "Dartignis"
+            }
         },
         {
             "name": "Talonflame",
@@ -18337,7 +20980,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Flambusard",
+                "german": "Fiaro"
+            }
         },
         {
             "name": "Scatterbug",
@@ -18364,7 +21011,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "L\u00e9pidonille",
+                "german": "Purmel"
+            }
         },
         {
             "name": "Spewpa",
@@ -18390,7 +21041,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "P\u00e9r\u00e9grain",
+                "german": "Puponcho"
+            }
         },
         {
             "name": "Vivillon",
@@ -18418,7 +21073,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Prismillon",
+                "german": "Vivillon"
+            }
         },
         {
             "name": "Litleo",
@@ -18446,7 +21105,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "H\u00e9lionceau",
+                "german": "Leufeo"
+            }
         },
         {
             "name": "Pyroar",
@@ -18474,7 +21137,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "N\u00e9m\u00e9lios",
+                "german": "Pyroleo"
+            }
         },
         {
             "name": "Flabebe",
@@ -18500,7 +21167,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Flab\u00e9b\u00e9",
+                "german": "Flab\u00e9b\u00e9"
+            }
         },
         {
             "name": "Floette",
@@ -18526,7 +21197,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Floette",
+                "german": "Floette"
+            }
         },
         {
             "name": "Florges",
@@ -18552,7 +21227,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Florges",
+                "german": "Florges"
+            }
         },
         {
             "name": "Skiddo",
@@ -18578,7 +21257,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Cabriolaine",
+                "german": "M\u00e4hikel"
+            }
         },
         {
             "name": "Gogoat",
@@ -18604,7 +21287,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Chevroum",
+                "german": "Chevrumm"
+            }
         },
         {
             "name": "Pancham",
@@ -18631,7 +21318,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Pandespi\u00e8gle",
+                "german": "Pam"
+            }
         },
         {
             "name": "Pangoro",
@@ -18659,7 +21350,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Pandarbare",
+                "german": "Pandagro"
+            }
         },
         {
             "name": "Furfrou",
@@ -18684,7 +21379,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Couafarel",
+                "german": "Coiffwaff"
+            }
         },
         {
             "name": "Espurr",
@@ -18711,7 +21410,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Psystigri",
+                "german": "Psiau"
+            }
         },
         {
             "name": "Meowstic",
@@ -18739,7 +21442,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Mistigrix",
+                "german": "Psiaugon"
+            }
         },
         {
             "name": "Honedge",
@@ -18765,7 +21472,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Monorpale",
+                "german": "Gramokles"
+            }
         },
         {
             "name": "Doublade",
@@ -18791,7 +21502,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Dimocl\u00e8s",
+                "german": "Duokles"
+            }
         },
         {
             "name": "Aegislash",
@@ -18817,7 +21532,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Exagide",
+                "german": "Durengard"
+            }
         },
         {
             "name": "Spritzee",
@@ -18843,7 +21562,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Fluvetin",
+                "german": "Parfi"
+            }
         },
         {
             "name": "Aromatisse",
@@ -18869,7 +21592,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Cocotine",
+                "german": "Parfinesse"
+            }
         },
         {
             "name": "Swirlix",
@@ -18895,7 +21622,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Sucroquin",
+                "german": "Flauschling"
+            }
         },
         {
             "name": "Slurpuff",
@@ -18921,7 +21652,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Cupcanaille",
+                "german": "Sabbaione"
+            }
         },
         {
             "name": "Inkay",
@@ -18949,7 +21684,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Sepiatop",
+                "german": "Iscalar"
+            }
         },
         {
             "name": "Malamar",
@@ -18977,7 +21716,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Sepiatroce",
+                "german": "Calamanero"
+            }
         },
         {
             "name": "Binacle",
@@ -19005,7 +21748,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Opermine",
+                "german": "Bithora"
+            }
         },
         {
             "name": "Barbaracle",
@@ -19033,7 +21780,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Golgopathe",
+                "german": "Thanathora"
+            }
         },
         {
             "name": "Skrelp",
@@ -19061,7 +21812,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Venalgue",
+                "german": "Algitt"
+            }
         },
         {
             "name": "Dragalge",
@@ -19089,7 +21844,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Kravarech",
+                "german": "Tandrak"
+            }
         },
         {
             "name": "Clauncher",
@@ -19114,7 +21873,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Flingouste",
+                "german": "Scampisto"
+            }
         },
         {
             "name": "Clawitzer",
@@ -19139,7 +21902,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Gamblast",
+                "german": "Wummer"
+            }
         },
         {
             "name": "Helioptile",
@@ -19167,7 +21934,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Galvaran",
+                "german": "Eguana"
+            }
         },
         {
             "name": "Heliolisk",
@@ -19195,7 +21966,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Iguolta",
+                "german": "Elezard"
+            }
         },
         {
             "name": "Tyrunt",
@@ -19222,7 +21997,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Ptyranidur",
+                "german": "Balgoras"
+            }
         },
         {
             "name": "Tyrantrum",
@@ -19249,7 +22028,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Rexillius",
+                "german": "Monargoras"
+            }
         },
         {
             "name": "Amaura",
@@ -19276,7 +22059,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Amagara",
+                "german": "Amarino"
+            }
         },
         {
             "name": "Aurorus",
@@ -19303,7 +22090,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Dragmara",
+                "german": "Amagarga"
+            }
         },
         {
             "name": "Sylveon",
@@ -19329,7 +22120,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Nymphali",
+                "german": "Feelinara"
+            }
         },
         {
             "name": "Hawlucha",
@@ -19357,7 +22152,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Brutalibr\u00e9",
+                "german": "Resladero"
+            }
         },
         {
             "name": "Dedenne",
@@ -19385,7 +22184,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Dedenne",
+                "german": "Dedenne"
+            }
         },
         {
             "name": "Carbink",
@@ -19412,7 +22215,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Strassie",
+                "german": "Rocara"
+            }
         },
         {
             "name": "Goomy",
@@ -19439,7 +22246,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Mucuscule",
+                "german": "Viscora"
+            }
         },
         {
             "name": "Sliggoo",
@@ -19466,7 +22277,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Colimucus",
+                "german": "Viscargot"
+            }
         },
         {
             "name": "Goodra",
@@ -19493,7 +22308,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Muplodocus",
+                "german": "Viscogon"
+            }
         },
         {
             "name": "Klefki",
@@ -19520,7 +22339,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Trousselin",
+                "german": "Clavion"
+            }
         },
         {
             "name": "Phantump",
@@ -19548,7 +22371,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Broc\u00e9l\u00f4me",
+                "german": "Paragoni"
+            }
         },
         {
             "name": "Trevenant",
@@ -19576,7 +22403,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Dess\u00e9liande",
+                "german": "Trombork"
+            }
         },
         {
             "name": "Pumpkaboo",
@@ -19604,7 +22435,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Pitrouille",
+                "german": "Irrbis"
+            }
         },
         {
             "name": "Gourgeist",
@@ -19632,7 +22467,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Banshitrouye",
+                "german": "Pumpdjinn"
+            }
         },
         {
             "name": "Bergmite",
@@ -19659,7 +22498,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Grela\u00e7on",
+                "german": "Arktip"
+            }
         },
         {
             "name": "Avalugg",
@@ -19686,7 +22529,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "S\u00e9racrawl",
+                "german": "Arktilas"
+            }
         },
         {
             "name": "Noibat",
@@ -19714,7 +22561,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Sonistrelle",
+                "german": "eF-eM"
+            }
         },
         {
             "name": "Noivern",
@@ -19742,7 +22593,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Bruyverne",
+                "german": "UHaFnir"
+            }
         },
         {
             "name": "Xerneas",
@@ -19767,7 +22622,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Xerneas",
+                "german": "Xerneas"
+            }
         },
         {
             "name": "Yveltal",
@@ -19793,7 +22652,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Yveltal",
+                "german": "Yveltal"
+            }
         },
         {
             "name": "Zygarde",
@@ -19820,7 +22683,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Zygarde",
+                "german": "Zygarde"
+            }
         },
         {
             "name": "Diancie",
@@ -19846,7 +22713,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Diancie",
+                "german": "Diancie"
+            }
         },
         {
             "name": "Hoopa",
@@ -19872,7 +22743,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Hoopa",
+                "german": "Hoopa"
+            }
         },
         {
             "name": "Volcanion",
@@ -19898,7 +22773,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 6
+            "gen": 6,
+            "name_language": {
+                "french": "Volcanion",
+                "german": "Volcanion"
+            }
         },
         {
             "name": "Rowlet",
@@ -19925,7 +22804,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Brindibou",
+                "german": "Bauz"
+            }
         },
         {
             "name": "Dartrix",
@@ -19952,7 +22835,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Effl\u00e8che",
+                "german": "Arboretoss"
+            }
         },
         {
             "name": "Decidueye",
@@ -19979,7 +22866,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Arch\u00e9duc",
+                "german": "Silvarro"
+            }
         },
         {
             "name": "Litten",
@@ -20005,7 +22896,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Flamiaou\u200e\u200e",
+                "german": "Flamiau"
+            }
         },
         {
             "name": "Torracat",
@@ -20031,7 +22926,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Matoufeu",
+                "german": "Miezunder"
+            }
         },
         {
             "name": "Incineroar",
@@ -20058,7 +22957,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "F\u00e9linferno",
+                "german": "Fuegro"
+            }
         },
         {
             "name": "Popplio",
@@ -20084,7 +22987,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Otaquin",
+                "german": "Robball"
+            }
         },
         {
             "name": "Brionne",
@@ -20110,7 +23017,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Otarlette",
+                "german": "Marikeck"
+            }
         },
         {
             "name": "Primarina",
@@ -20137,7 +23048,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Oratoria",
+                "german": "Primarene"
+            }
         },
         {
             "name": "Pikipek",
@@ -20165,7 +23080,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Picassaut",
+                "german": "Peppeck"
+            }
         },
         {
             "name": "Trumbeak",
@@ -20193,7 +23112,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Piclairon",
+                "german": "Trompeck"
+            }
         },
         {
             "name": "Toucannon",
@@ -20221,7 +23144,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Bazoucan",
+                "german": "Tukanon"
+            }
         },
         {
             "name": "Yungoos",
@@ -20248,7 +23175,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Manglouton",
+                "german": "Mangunior"
+            }
         },
         {
             "name": "Gumshoos",
@@ -20275,7 +23206,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Argouste",
+                "german": "Manguspektor"
+            }
         },
         {
             "name": "Grubbin",
@@ -20300,7 +23235,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Larvibule",
+                "german": "Mabula"
+            }
         },
         {
             "name": "Charjabug",
@@ -20326,7 +23265,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Chrysapile",
+                "german": "Akkup"
+            }
         },
         {
             "name": "Vikavolt",
@@ -20352,7 +23295,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Lucanon",
+                "german": "Donarion"
+            }
         },
         {
             "name": "Crabrawler",
@@ -20379,7 +23326,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Crabagarre",
+                "german": "Krabbox"
+            }
         },
         {
             "name": "Crabominable",
@@ -20407,7 +23358,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Crabominable",
+                "german": "Krawell"
+            }
         },
         {
             "name": "Oricorio",
@@ -20433,7 +23388,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Plumeline",
+                "german": "Choreogel"
+            }
         },
         {
             "name": "Cutiefly",
@@ -20461,7 +23420,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Bombydou",
+                "german": "Wommel"
+            }
         },
         {
             "name": "Ribombee",
@@ -20489,7 +23452,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Rubombelle",
+                "german": "Bandelby"
+            }
         },
         {
             "name": "Rockruff",
@@ -20516,7 +23483,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Rocabot",
+                "german": "Wuffels"
+            }
         },
         {
             "name": "Lycanroc",
@@ -20546,7 +23517,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Lougaroc",
+                "german": "Wolwerock"
+            }
         },
         {
             "name": "Wishiwashi",
@@ -20571,7 +23546,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Froussardine",
+                "german": "Lusardin"
+            }
         },
         {
             "name": "Mareanie",
@@ -20599,7 +23578,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Vorast\u00e9rie",
+                "german": "Garstella"
+            }
         },
         {
             "name": "Toxapex",
@@ -20627,7 +23610,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Pr\u00e9dast\u00e9rie",
+                "german": "Aggrostella"
+            }
         },
         {
             "name": "Mudbray",
@@ -20654,7 +23641,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tiboudet",
+                "german": "Pampuli"
+            }
         },
         {
             "name": "Mudsdale",
@@ -20681,7 +23672,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Bourrinos",
+                "german": "Pampross"
+            }
         },
         {
             "name": "Dewpider",
@@ -20708,7 +23703,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Araqua",
+                "german": "Araqua"
+            }
         },
         {
             "name": "Araquanid",
@@ -20735,7 +23734,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tarenbulle",
+                "german": "Aranestro"
+            }
         },
         {
             "name": "Fomantis",
@@ -20761,7 +23764,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Mimantis",
+                "german": "Imantis"
+            }
         },
         {
             "name": "Lurantis",
@@ -20787,7 +23794,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Floramantis",
+                "german": "Mantidea"
+            }
         },
         {
             "name": "Morelull",
@@ -20815,7 +23826,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Spododo",
+                "german": "Bubungus"
+            }
         },
         {
             "name": "Shiinotic",
@@ -20843,7 +23858,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Lampignon",
+                "german": "Lamellux"
+            }
         },
         {
             "name": "Salandit",
@@ -20870,7 +23889,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tritox",
+                "german": "Molunk"
+            }
         },
         {
             "name": "Salazzle",
@@ -20897,7 +23920,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Malamandre",
+                "german": "Amfira"
+            }
         },
         {
             "name": "Stufful",
@@ -20925,7 +23952,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Nounourson",
+                "german": "Velursi"
+            }
         },
         {
             "name": "Bewear",
@@ -20953,7 +23984,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Chelours",
+                "german": "Kosturso"
+            }
         },
         {
             "name": "Bounsweet",
@@ -20980,7 +24015,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Croquine",
+                "german": "Frubberl"
+            }
         },
         {
             "name": "Steenee",
@@ -21007,7 +24046,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Candine",
+                "german": "Frubaila"
+            }
         },
         {
             "name": "Tsareena",
@@ -21034,7 +24077,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Sucreine",
+                "german": "Fruyal"
+            }
         },
         {
             "name": "Comfey",
@@ -21061,7 +24108,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Gu\u00e9rilande",
+                "german": "Curelei"
+            }
         },
         {
             "name": "Oranguru",
@@ -21089,7 +24140,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Gouroutan",
+                "german": "Kommandutan"
+            }
         },
         {
             "name": "Passimian",
@@ -21115,7 +24170,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Quartermac",
+                "german": "Quartermak"
+            }
         },
         {
             "name": "Wimpod",
@@ -21141,7 +24200,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Sovkipou",
+                "german": "Rei\u00dflaus"
+            }
         },
         {
             "name": "Golisopod",
@@ -21167,7 +24230,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Sarmura\u00ef",
+                "german": "Tectass"
+            }
         },
         {
             "name": "Sandygast",
@@ -21194,7 +24261,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Bacabouh",
+                "german": "Sankabuh"
+            }
         },
         {
             "name": "Palossand",
@@ -21221,7 +24292,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tr\u00e9passable",
+                "german": "Colossand"
+            }
         },
         {
             "name": "Pyukumuku",
@@ -21247,7 +24322,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Concombaffe",
+                "german": "Gufa"
+            }
         },
         {
             "name": "Type: Null",
@@ -21272,7 +24351,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Type:0",
+                "german": "Typ:Null"
+            }
         },
         {
             "name": "Silvally",
@@ -21297,7 +24380,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Silvalli\u00e9",
+                "german": "Amigento"
+            }
         },
         {
             "name": "Minior",
@@ -21323,7 +24410,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "M\u00e9t\u00e9no",
+                "german": "Meteno"
+            }
         },
         {
             "name": "Komala",
@@ -21348,7 +24439,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Dodoala",
+                "german": "Koalelu"
+            }
         },
         {
             "name": "Turtonator",
@@ -21374,7 +24469,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Boumata",
+                "german": "Tortunator"
+            }
         },
         {
             "name": "Togedemaru",
@@ -21402,7 +24501,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Togedemaru",
+                "german": "Togedemaru"
+            }
         },
         {
             "name": "Mimikyu",
@@ -21428,7 +24531,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Mimiqui",
+                "german": "Mimigma"
+            }
         },
         {
             "name": "Bruxish",
@@ -21456,7 +24563,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Denticrisse",
+                "german": "Knirfish"
+            }
         },
         {
             "name": "Drampa",
@@ -21484,7 +24595,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Dra\u00efeul",
+                "german": "Sen-Long"
+            }
         },
         {
             "name": "Dhelmise",
@@ -21510,7 +24625,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Sinistrail",
+                "german": "Moruda"
+            }
         },
         {
             "name": "Jangmo-o",
@@ -21537,7 +24656,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "B\u00e9b\u00e9caille",
+                "german": "Miniras"
+            }
         },
         {
             "name": "Hakamo-o",
@@ -21565,7 +24688,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "\u00c9ca\u00efd",
+                "german": "Mediras"
+            }
         },
         {
             "name": "Kommo-o",
@@ -21593,7 +24720,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "\u00c9ka\u00efser",
+                "german": "Grandiras"
+            }
         },
         {
             "name": "Tapu Koko",
@@ -21620,7 +24751,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tokorico",
+                "german": "Kapu-Riki"
+            }
         },
         {
             "name": "Tapu Lele",
@@ -21647,7 +24782,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tokopiyon",
+                "german": "Kapu-Fala"
+            }
         },
         {
             "name": "Tapu Bulu",
@@ -21674,7 +24813,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tokotoro",
+                "german": "Kapu-Toro"
+            }
         },
         {
             "name": "Tapu Fini",
@@ -21701,7 +24844,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Tokopisco",
+                "german": "Kapu-Kime"
+            }
         },
         {
             "name": "Cosmog",
@@ -21726,7 +24873,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Cosmog",
+                "german": "Cosmog"
+            }
         },
         {
             "name": "Cosmoem",
@@ -21751,7 +24902,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Cosmovum",
+                "german": "Cosmovum"
+            }
         },
         {
             "name": "Solgaleo",
@@ -21777,7 +24932,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Solgaleo",
+                "german": "Solgaleo"
+            }
         },
         {
             "name": "Lunala",
@@ -21803,7 +24962,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Lunala",
+                "german": "Lunala"
+            }
         },
         {
             "name": "Nihilego",
@@ -21829,7 +24992,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Z\u00e9ro\u00efd",
+                "german": "Anego"
+            }
         },
         {
             "name": "Buzzwole",
@@ -21855,7 +25022,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Mouscoto",
+                "german": "Masskito"
+            }
         },
         {
             "name": "Pheromosa",
@@ -21881,7 +25052,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Cancrelove",
+                "german": "Schabelle"
+            }
         },
         {
             "name": "Xurkitree",
@@ -21906,7 +25081,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "C\u00e2blif\u00e8re",
+                "german": "Voltriant"
+            }
         },
         {
             "name": "Celesteela",
@@ -21932,7 +25111,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Bamboiselle",
+                "german": "Kaguron"
+            }
         },
         {
             "name": "Kartana",
@@ -21958,7 +25141,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Katagami",
+                "german": "Katagami"
+            }
         },
         {
             "name": "Guzzlord",
@@ -21984,7 +25171,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Engloutyran",
+                "german": "Schlingking"
+            }
         },
         {
             "name": "Necrozma",
@@ -22009,7 +25200,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Necrozma",
+                "german": "Necrozma"
+            }
         },
         {
             "name": "Magearna",
@@ -22035,7 +25230,11 @@
             },
             "evolution": [],
             "description": "Description not available yet",
-            "gen": 7
+            "gen": 7,
+            "name_language": {
+                "french": "Magearna",
+                "german": "Magearna"
+            }
         }
     ]
 }

--- a/data/pokemondb.json
+++ b/data/pokemondb.json
@@ -4299,6 +4299,11 @@
         {
             "id": 143,
             "name": "Snorlax",
+            "name_language": {
+                "french": "Ronflex",
+                "german": "Relaxo",
+                "spanish": "Snorlax"
+            },
             "species": "Sleeping Pokemon",
             "type": [
                 "Normal"

--- a/data/stories.md
+++ b/data/stories.md
@@ -42,6 +42,8 @@
   - utter_joke
 * confirm_exists
   - action_check_existence
+* name_translation
+  - action_translate_name
 
 ## faq
 * faq

--- a/domain.yml
+++ b/domain.yml
@@ -1,5 +1,6 @@
 actions:
 - action_check_existence
+- action_translate_name
 - action_query_knowledge_base
 - respond_faq
 - utter_ask_rephrase
@@ -16,8 +17,10 @@ entities:
 - object_type
 - pokemon
 - pokemon_name
+- language
 intents:
 - confirm_exists
+- name_translation
 - greet
 - faq
 - goodbye

--- a/domain.yml
+++ b/domain.yml
@@ -54,7 +54,7 @@ responses:
   - text: What appears over Ash’s head when he gets an idea? A LightBulbasaur
   - text: Where did Brock take Nurse Joy for a date? The PokeBall
   - text: What’s better than one Pikachu? PikaTWO
-  - text: What does Moeowth see when it looks in the mirror? A copy-cat!
+  - text: What does Meowth see when it looks in the mirror? A copy-cat!
   - text: When does a Gastly eat breakfast? In the moaning.
   - text: Which Pokemon does Dracula like most? Koffin'
   - text: What's everybody's favorite dance in the Pokemon world? The PokeBall!


### PR DESCRIPTION
This PR, which involves issue #8, is the first try at translating Pokemon names. At the time being, only one Pokemon—Snorlax—has its French, German, and Spanish name variant in the database file.

The translation features use a custom action. 
Below is an example. Note that the language name is in lowercase.

```
Your input ->  What is the french name of Snorlax?                                                                                                                                        
Snorlax's french name is Ronflex.
Your input ->  What is the spanish name of Snorlax?                                                                                                                                       
Snorlax's spanish name is Snorlax.
Your input ->  What is the german name of Snorlax?                                                                                                                                        
Snorlax's german name is Relaxo.
Your input ->  What is the dutch name of Snorlax?                                                                                                                                         
I don't know that translation.
```


